### PR TITLE
Make BaseOrbitContainer only emit `LifecycleAction.Created` when the middleware's initial value is not seeded

### DIFF
--- a/orbit/src/test/java/com/babylon/orbit/OrbitContainerSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/OrbitContainerSpek.kt
@@ -538,44 +538,19 @@ internal class OrbitContainerSpek : Spek({
                 sideEffectTestObserver.assertNoValues()
             }
         }
-    }
 
-    Feature("Container - Sending LifecycleAction.Created on creation") {
-        Scenario("When using middleware's initial value") {
-            lateinit var middleware: Middleware<TestState, String>
-            val sideEffectSubject = PublishSubject.create<String>()
-            val sideEffectTestObserver = sideEffectSubject.test()
-
-            Given("A non-seeded container with a side effect off a LifecycleEvent.Created") {
-                middleware = createTestMiddleware {
-                    perform("check lifecycle action")
-                        .on<LifecycleAction.Created>()
-                        .sideEffect { sideEffectSubject.onNext("foo") }
-                }
-                BaseOrbitContainer(middleware)
-            }
-
-            When("I connect to the middleware") {
-                sideEffectTestObserver.awaitCount(1)
-            }
-
-            Then("No side effect is received") {
-                sideEffectTestObserver.assertValue("foo")
-            }
-        }
-
-        Scenario("When overriding middleware's initial value") {
+        Scenario("Lifecycle action not sent on container creation for container seeded with same state as middleware's initial state") {
             lateinit var middleware: Middleware<TestState, String>
             val sideEffectSubject = PublishSubject.create<String>()
             val sideEffectTestObserver = sideEffectSubject.test()
 
             Given("A seeded container with a side effect off a LifecycleEvent.Created") {
-                middleware = createTestMiddleware {
+                middleware = createTestMiddleware(initialState = TestState(123)) {
                     perform("check lifecycle action")
                         .on<LifecycleAction.Created>()
                         .sideEffect { sideEffectSubject.onNext("foo") }
                 }
-                BaseOrbitContainer(middleware, TestState(1234567890))
+                BaseOrbitContainer(middleware, TestState(123))
             }
 
             When("I connect to the middleware") {
@@ -586,6 +561,5 @@ internal class OrbitContainerSpek : Spek({
                 sideEffectTestObserver.assertNoValues()
             }
         }
-
     }
 })

--- a/orbit/src/test/java/com/babylon/orbit/OrbitContainerSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/OrbitContainerSpek.kt
@@ -539,4 +539,53 @@ internal class OrbitContainerSpek : Spek({
             }
         }
     }
+
+    Feature("Container - Sending LifecycleAction.Created on creation") {
+        Scenario("When using middleware's initial value") {
+            lateinit var middleware: Middleware<TestState, String>
+            val sideEffectSubject = PublishSubject.create<String>()
+            val sideEffectTestObserver = sideEffectSubject.test()
+
+            Given("A non-seeded container with a side effect off a LifecycleEvent.Created") {
+                middleware = createTestMiddleware {
+                    perform("check lifecycle action")
+                        .on<LifecycleAction.Created>()
+                        .sideEffect { sideEffectSubject.onNext("foo") }
+                }
+                BaseOrbitContainer(middleware)
+            }
+
+            When("I connect to the middleware") {
+                sideEffectTestObserver.awaitCount(1)
+            }
+
+            Then("No side effect is received") {
+                sideEffectTestObserver.assertValue("foo")
+            }
+        }
+
+        Scenario("When overriding middleware's initial value") {
+            lateinit var middleware: Middleware<TestState, String>
+            val sideEffectSubject = PublishSubject.create<String>()
+            val sideEffectTestObserver = sideEffectSubject.test()
+
+            Given("A seeded container with a side effect off a LifecycleEvent.Created") {
+                middleware = createTestMiddleware {
+                    perform("check lifecycle action")
+                        .on<LifecycleAction.Created>()
+                        .sideEffect { sideEffectSubject.onNext("foo") }
+                }
+                BaseOrbitContainer(middleware, TestState(1234567890))
+            }
+
+            When("I connect to the middleware") {
+                sideEffectTestObserver.awaitCount(1)
+            }
+
+            Then("No side effect is received") {
+                sideEffectTestObserver.assertNoValues()
+            }
+        }
+
+    }
 })


### PR DESCRIPTION
Rationale for this:

In some tests we want to override the initial value. If this happens to be the middleware's initial value then the container emits `LifecycleAction.Created` which in some cases might trigger other bits of logic than can further modify the state, making our tests harder to reason (and even introduces flakiness if those situations happen "randomly").