### PR TITLE
Reducer fix

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,9 +8,6 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <MarkdownNavigatorCodeStyleSettings>
-      <option name="RIGHT_MARGIN" value="72" />
-    </MarkdownNavigatorCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/.idea/copyright/Babylon.xml
+++ b/.idea/copyright/Babylon.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright 2019 Babylon Partners Limited&#10; &#10; Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10; you may not use this file except in compliance with the License.&#10; You may obtain a copy of the License at&#10; &#10; http://www.apache.org/licenses/LICENSE-2.0&#10; &#10; Unless required by applicable law or agreed to in writing, software&#10; distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10; See the License for the specific language governing permissions and&#10; limitations under the License." />
+    <option name="notice" value="Copyright 2020 Babylon Partners Limited&#10; &#10; Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10; you may not use this file except in compliance with the License.&#10; You may obtain a copy of the License at&#10; &#10; http://www.apache.org/licenses/LICENSE-2.0&#10; &#10; Unless required by applicable law or agreed to in writing, software&#10; distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10; See the License for the specific language governing permissions and&#10; limitations under the License." />
     <option name="myName" value="Babylon" />
   </copyright>
 </component>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -114,7 +114,7 @@ val viewModelModule = module {
     viewModel { (handle: SavedStateHandle) -> MyViewModel(handle) }
 }
 
-// Inject as a stateViewModel in your Activity or Fragment 
+// Inject as a stateViewModel in your Activity or Fragment
 private val viewModel by stateViewModel<TodoViewModel>()
 
 // Pass the SavedStateHandle to the OrbitViewModel base class

--- a/orbit/src/main/java/com/babylon/orbit/EventReceiver.kt
+++ b/orbit/src/main/java/com/babylon/orbit/EventReceiver.kt
@@ -17,7 +17,15 @@
 package com.babylon.orbit
 
 /**
- * @property event The incoming event.
+ * @property event will be the result of the upstream operator
+ *
+ * If the upstream is:
+ *
+ * - `on` - `event` will be the action coming into the flow
+ * - `transform` - `event` will be the emission from the transformed observable
+ * - `reduce` - `event` will be the reduced state
+ * - `sideEffect` - `event` will be whatever the operator further upstream emits
+ * - `loopBack` - `event` will be whatever the operator further upstream emits
  */
 @OrbitDsl
 class EventReceiver<STATE : Any, EVENT : Any>(

--- a/orbit/src/main/java/com/babylon/orbit/OrbitContext.kt
+++ b/orbit/src/main/java/com/babylon/orbit/OrbitContext.kt
@@ -18,6 +18,7 @@ package com.babylon.orbit
 
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
+import java.util.*
 
 typealias TransformerFunction<STATE, SIDE_EFFECT> = OrbitContext<STATE, SIDE_EFFECT>.() -> (Observable<*>)
 
@@ -25,7 +26,18 @@ data class OrbitContext<STATE : Any, SIDE_EFFECT : Any>(
     val currentStateProvider: () -> STATE,
     val rawActions: Observable<*>,
     val inputSubject: PublishSubject<Any>,
-    val reducerSubject: PublishSubject<(STATE) -> STATE>,
+    val partialReducerSubject: PublishSubject<PartialReducer<STATE>>,
+    val reductionSubject: PublishSubject<Reduction<STATE>>,
     val sideEffectSubject: PublishSubject<SIDE_EFFECT>,
     val ioScheduled: Boolean
+)
+
+data class PartialReducer<STATE : Any>(
+    val uuid: UUID,
+    val reduce: (STATE) -> STATE
+)
+
+data class Reduction<STATE : Any>(
+    val uuid: UUID,
+    val state: STATE
 )

--- a/orbit/src/main/java/com/babylon/orbit/OrbitContext.kt
+++ b/orbit/src/main/java/com/babylon/orbit/OrbitContext.kt
@@ -17,8 +17,8 @@
 package com.babylon.orbit
 
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
-import java.util.*
 
 typealias TransformerFunction<STATE, SIDE_EFFECT> = OrbitContext<STATE, SIDE_EFFECT>.() -> (Observable<*>)
 
@@ -26,18 +26,6 @@ data class OrbitContext<STATE : Any, SIDE_EFFECT : Any>(
     val currentStateProvider: () -> STATE,
     val rawActions: Observable<*>,
     val inputSubject: PublishSubject<Any>,
-    val partialReducerSubject: PublishSubject<PartialReducer<STATE>>,
-    val reductionSubject: PublishSubject<Reduction<STATE>>,
-    val sideEffectSubject: PublishSubject<SIDE_EFFECT>,
-    val ioScheduled: Boolean
-)
-
-data class PartialReducer<STATE : Any>(
-    val uuid: UUID,
-    val reduce: (STATE) -> STATE
-)
-
-data class Reduction<STATE : Any>(
-    val uuid: UUID,
-    val state: STATE
+    val reduce: ((STATE) -> STATE) -> Single<STATE>,
+    val sideEffectSubject: PublishSubject<SIDE_EFFECT>
 )

--- a/orbit/src/main/java/com/babylon/orbit/OrbitsBuilder.kt
+++ b/orbit/src/main/java/com/babylon/orbit/OrbitsBuilder.kt
@@ -159,7 +159,8 @@ open class OrbitsBuilder<STATE : Any, SIDE_EFFECT : Any>(private val initialStat
         /**
          * Reducers reduce the current state and incoming events to produce a new state.
          *
-         * Downstream transformers await for the state to be reduced and are then passed the new state.
+         * Downstream transformers await for the state to be reduced and are then passed the new state
+         * as the incoming event.
          *
          * @param reducer the lambda reducing the current state and incoming event to produce a new state
          */

--- a/orbit/src/main/java/com/babylon/orbit/SideEffectEventReceiver.kt
+++ b/orbit/src/main/java/com/babylon/orbit/SideEffectEventReceiver.kt
@@ -17,9 +17,16 @@
 package com.babylon.orbit
 
 import io.reactivex.subjects.Subject
-
 /**
- * @property event The incoming event.
+ * @property event will be the result of the upstream operator
+ *
+ * If the upstream is:
+ *
+ * - `on` - `event` will be the action coming into the flow
+ * - `transform` - `event` will be the emission from the transformed observable
+ * - `reduce` - `event` will be the reduced state
+ * - `sideEffect` - `event` will be whatever the operator further upstream emits
+ * - `loopBack` - `event` will be whatever the operator further upstream emits
  */
 @OrbitDsl
 class SideEffectEventReceiver<STATE : Any, EVENT : Any, SIDE_EFFECT : Any>(

--- a/orbit/src/test/java/com/babylon/orbit/DslSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/DslSpek.kt
@@ -50,7 +50,7 @@ internal class DslSpek : Spek({
                 .sideEffect { println("$event") }
                 .sideEffect { post("$event") }
                 .reduce { TestState(currentState.id + event) }
-                .transform { eventObservable.map { currentState.id + it + 2 } }
+                .transform { eventObservable.map { it.id + 2 } }
         }
 
         Scenario("trying to build flows with the same description throw an exception") {
@@ -501,7 +501,7 @@ internal class DslSpek : Spek({
                         }
                         .transform {
                             eventObservable.flatMapIterable {
-                                listOf(it * 111, it * 1111)
+                                listOf(it.id * 111, it.id * 1111)
                             }
                         }
                         .reduce {

--- a/orbit/src/test/java/com/babylon/orbit/DslSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/DslSpek.kt
@@ -269,7 +269,7 @@ internal class DslSpek : Spek({
                 repeat(100) {
                     expectedStates.add(TestState(42 + (it + 1) * 2))
                 }
-                assertThat(listOfStates).isEqualTo(expectedStates)
+                assertThat(listOfStates).containsExactlyElementsOf(expectedStates)
             }
         }
 
@@ -307,7 +307,7 @@ internal class DslSpek : Spek({
                 repeat(100) {
                     expectedStates.add(TestState(42 + (it + 1) * 2))
                 }
-                assertThat(listOfStates).isEqualTo(expectedStates)
+                assertThat(listOfStates).containsExactlyElementsOf(expectedStates)
             }
         }
 
@@ -337,13 +337,13 @@ internal class DslSpek : Spek({
                 }
             }
 
-            Then("The states captured by the transformer are correct") {
+            Then("The states captured by the loopback are correct") {
                 testObserver.awaitCount(100)
                 val expectedStates = mutableListOf<TestState>()
                 repeat(100) {
                     expectedStates.add(TestState(42 + (it + 1) * 2))
                 }
-                assertThat(listOfStates).isEqualTo(expectedStates)
+                assertThat(listOfStates).containsExactlyElementsOf(expectedStates)
             }
         }
 

--- a/orbit/src/test/java/com/babylon/orbit/OrbitContainerThreadingSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/OrbitContainerThreadingSpek.kt
@@ -279,7 +279,7 @@ internal class OrbitContainerThreadingSpek : Spek({
             }
         }
 
-        Scenario("The downstream side effect of a reducer execute on reducer thread") {
+        Scenario("The downstream side effect of a reducer executes on IO thread") {
             lateinit var middleware: Middleware<TestState, String>
             lateinit var orbitContainer: BaseOrbitContainer<TestState, String>
             val testSubject = PublishSubject.create<Int>()

--- a/orbit/src/test/java/com/babylon/orbit/OrbitContainerThreadingSpek.kt
+++ b/orbit/src/test/java/com/babylon/orbit/OrbitContainerThreadingSpek.kt
@@ -246,7 +246,7 @@ internal class OrbitContainerThreadingSpek : Spek({
                             currentState
                         }
                         .transform {
-                            eventObservable.map { it * 2 }
+                            eventObservable.map { it.id * 2 }
                                 .doOnNext {
                                     firstransformThreadName = Thread.currentThread().name
                                     testSubject.onNext(it)
@@ -272,6 +272,67 @@ internal class OrbitContainerThreadingSpek : Spek({
 
             And("The first transformer runs on the IO thread") {
                 assertThat(firstransformThreadName).isEqualTo("IO")
+            }
+
+            And("The second reducer runs on the reducer thread") {
+                assertThat(secondReducerThreadName).isEqualTo("reducerThread")
+            }
+        }
+
+        Scenario("The downstream side effect of a reducer execute on reducer thread") {
+            lateinit var middleware: Middleware<TestState, String>
+            lateinit var orbitContainer: BaseOrbitContainer<TestState, String>
+            val testSubject = PublishSubject.create<Int>()
+            val testObserver = testSubject.test()
+            lateinit var transformThreadName: String
+            lateinit var firstReducerThreadName: String
+            lateinit var secondReducerThreadName: String
+            lateinit var sideEffectThreadName: String
+
+            Given("A middleware with a mix of reducers and transformers") {
+                middleware = createTestMiddleware {
+                    perform("something")
+                        .on<Int>()
+                        .transform {
+                            eventObservable.map { currentState.id * 2 }
+                                .doOnNext {
+                                    transformThreadName = Thread.currentThread().name
+                                    testSubject.onNext(it)
+                                }
+                        }
+                        .reduce {
+                            firstReducerThreadName = Thread.currentThread().name
+                            testSubject.onNext(event)
+                            currentState.copy(currentState.id + 1)
+                        }
+                        .sideEffect {
+                            sideEffectThreadName = Thread.currentThread().name
+                            testSubject.onNext(event.id)
+                        }
+                        .reduce {
+                            secondReducerThreadName = Thread.currentThread().name
+                            testSubject.onNext(event.id)
+                            currentState.copy(currentState.id + 1)
+                        }
+                }
+                orbitContainer = BaseOrbitContainer(middleware)
+            }
+
+            When("sending an action") {
+                orbitContainer.sendAction(5)
+                testObserver.awaitCount(3)
+            }
+
+            Then("The transformer runs on the io thread") {
+                assertThat(transformThreadName).isEqualTo("IO")
+            }
+
+            And("The first reducer runs on the reducer thread") {
+                assertThat(firstReducerThreadName).isEqualTo("reducerThread")
+            }
+
+            And("The side effect runs on the IO thread") {
+                assertThat(sideEffectThreadName).isEqualTo("IO")
             }
 
             And("The second reducer runs on the reducer thread") {


### PR DESCRIPTION
There is an expectation that `event` downstream of a reducer will be the reduced state. 

Fixing this means that the reducer is no longer a passthrough transformer - breaking change.