### PR TITLE
Update broken version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI status](https://github.com/babylonhealth/orbit-mvi/workflows/Android%20CI/badge.svg)](https://github.com/babylonhealth/orbit-mvi/actions)
 [![codecov](https://codecov.io/gh/babylonhealth/orbit-mvi/branch/master/graph/badge.svg)](https://codecov.io/gh/babylonhealth/orbit-mvi)
-[![Download](https://api.bintray.com/packages/babylonpartners/maven/orbit/images/download.svg)](https://bintray.com/babylonpartners/maven/orbit/_latestVersion)
+[![Download](https://api.bintray.com/packages/babylonpartners/maven/orbit/images/download.svg?version=3.4.0) ](https://bintray.com/babylonpartners/maven/orbit/3.4.0/link)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
 
 ![Logo](images/logo.png)


### PR DESCRIPTION
JCenter does not correctly update the latest version badge based on semantic versioning so temporarily fix it until we release a new version