### PR TITLE
Rethinking supported connection methods

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,7 +4,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -20,6 +20,9 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <MarkdownNavigatorCodeStyleSettings>
+      <option name="WRAP_ON_TYPING" value="1" />
+    </MarkdownNavigatorCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ from scratch.
 
 ### Orbit ❤️ Android
 
-- Subscribe to state and side effects through LiveData
+- Subscribe to state and side effects through Flow
 - ViewModel support, along with SavedState!
 
 ### Testing 🤖
@@ -159,9 +159,13 @@ projects as well as lifecycle independent services.
 
 ## Connecting to a ViewModel
 
-Now we need to wire up the `ViewModel` to our UI. Orbit provides various methods
-of connecting via optional modules. For Android, the most convenient way to
-connect is via `LiveData`, as it manages subscription disposal automatically.
+Now we need to wire up the `ViewModel` to our UI. We expose coroutine
+`Flow`s through which one can conveniently subscribe to updates.
+Alternatively you can convert these to your preferred type using
+externally provided extension methods e.g.
+[asLiveData](https://developer.android.com/reference/kotlin/androidx/lifecycle/package-summary#(kotlinx.coroutines.flow.Flow).asLiveData(kotlin.coroutines.CoroutineContext,%20kotlin.Long))
+or
+[asObservable](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/kotlinx.coroutines.flow.-flow/as-observable.html).
 
 ``` kotlin
 class CalculatorActivity: AppCompatActivity() {
@@ -174,10 +178,12 @@ class CalculatorActivity: AppCompatActivity() {
         addButton.setOnClickListener { viewModel.add(1234) }
         subtractButton.setOnClickListener { viewModel.subtract(1234) }
 
-        // NOTE: Live data support is provided by the live data module:
-        // com.babylon.orbit2:orbit-livedata
-        viewModel.container.stateLiveData.observe(this) { render(it) }
-        viewModel.container.sideEffectLiveData.observe(this) { handleSideEffect(it) }
+        lifecycleScope.launchWhenCreated {
+            viewModel.container.stateFlow.collect { render(it) }
+        }
+        lifecycleScope.launchWhenCreated {
+            viewModel.container.sideEffectFlow.collect { handleSideEffect(it) }
+        }
     }
 
     private fun render(state: CalculatorState) {

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ class CalculatorActivity: AppCompatActivity() {
 
         // NOTE: Live data support is provided by the live data module:
         // com.babylon.orbit2:orbit-livedata
-        viewModel.container.state.observe(this, Observer { render(it) })
-        viewModel.container.sideEffect.observe(this, Observer { handleSideEffect(it) })
+        viewModel.container.stateLiveData.observe(this) { render(it) }
+        viewModel.container.sideEffectLiveData.observe(this) { handleSideEffect(it) }
     }
 
     private fun render(state: CalculatorState) {

--- a/orbit-2-core/README.md
+++ b/orbit-2-core/README.md
@@ -128,6 +128,7 @@ fun main() {
     val container = container<ExampleState, ExampleSideEffect>(ExampleState())
 
     // subscribe to updates
+    // For Android, use `lifecycleScope.launchWhenCreated` instead
     CoroutineScope(Dispatchers.Main).launch {
         container.stateFlow.collect {
             // do something with the state

--- a/orbit-2-core/README.md
+++ b/orbit-2-core/README.md
@@ -7,6 +7,7 @@ It provides all the basic parts of Orbit.
   - [Architecture](#architecture)
     - [Orbit concepts](#orbit-concepts)
     - [Side effects](#side-effects)
+      - [Limitations](#limitations)
   - [Including the module](#including-the-module)
   - [Orbit container](#orbit-container)
     - [Subscribing to the container](#subscribing-to-the-container)
@@ -77,6 +78,17 @@ The UI does not have to be aware of all side effects (e.g. why should the UI
 care if you send analytics events?). As such you can have side effects that do
 not post any event back to the UI.
 
+Side effects are cached if there are no observers, guaranteeing critical
+events such as navigation are delivered after re-subscription.
+
+#### Limitations
+
+`Container.sideEffectFlow` is designed to be collected by only one
+observer. This ensures that side effect caching works in a predictable
+way. If your particular use case requires multi-casting use `broadcast`
+on the side effect flow, but be aware that caching will not work for the
+resulting `BroadcastChannel`.
+
 ## Including the module
 
 Orbit 2 is a modular framework. You will need this module to get started!
@@ -120,6 +132,8 @@ fun main() {
         container.stateFlow.collect {
             // do something with the state
         }
+    }
+    CoroutineScope(Dispatchers.Main).launch {
         container.sideEffectFlow.collect {
             // do something with the side effect
         }

--- a/orbit-2-core/README.md
+++ b/orbit-2-core/README.md
@@ -345,10 +345,6 @@ done within particular `transform` blocks e.g. `transformSuspend`.
 - `transform` and `transformX` calls execute in an `IO` thread so as not to
   block the Orbit [Container](src/main/java/com/babylon/orbit2/Container.kt)
   from accepting further events.
-- Updates delivered via `Container.stateStream` and
-  `Container.sideEffectStream` come in on the main coroutine dispatcher
-  if installed, with the default dispatcher as the fallback. However,
-  the connection to the stream has to be manually managed and cancelled.
 
 ## Error handling
 

--- a/orbit-2-core/orbit-2-core_build.gradle.kts
+++ b/orbit-2-core/orbit-2-core_build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     // Testing
     testImplementation(project(":orbit-2-test"))
+    testImplementation(ProjectDependencies.kotlinCoroutinesTest)
     GroupedDependencies.testsImplementation.forEach { testImplementation(it) }
     testRuntimeOnly(ProjectDependencies.junitJupiterEngine)
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/BaseDslPlugin.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/BaseDslPlugin.kt
@@ -123,7 +123,7 @@ object BaseDslPlugin : OrbitDslPlugin {
             }
             is Reduce -> flow.onEach { event ->
                 containerContext.withIdling(operator) {
-                    containerContext.setState.send(
+                    containerContext.setState(
                         createContext(event).block() as S
                     )
                 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -18,6 +18,7 @@ package com.babylon.orbit2
 
 import com.babylon.orbit2.idling.IdlingResource
 import com.babylon.orbit2.idling.NoopIdlingResource
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -36,14 +37,19 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
 
     /**
      * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
-     * values (only changed states are emitted) by default.
+     * values (through equality comparison).
      */
     val stateFlow: Flow<STATE>
 
     /**
-     * A [Flow] of one-off side effects posted from [Builder.sideEffect].
-     * Depending on the [Settings] this container has been instantiated with, can support
-     * side effect caching when there are no listeners (default).
+     * A [Flow] of one-off side effects posted from [Builder.sideEffect]. Caches side effects when there are no collectors.
+     * The size of the cache can be controlled via Container [Settings] and determines if and when the orbit thread suspends when you
+     * post a side effect. The default is unlimited. You don't have to touch this unless you are posting many side effects which could result in
+     * [OutOfMemoryError].
+     *
+     * This is designed to be collected by one observer only in order to ensure that side effect caching works in a predictable way.
+     * If your particular use case requires multi-casting use `broadcast` on this [Flow], but be aware that caching will not work for the
+     * resulting `BroadcastChannel`.
      */
     val sideEffectFlow: Flow<SIDE_EFFECT>
 
@@ -77,12 +83,13 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
     /**
      * Represents additional settings to create the container with.
      *
-     * @property sideEffectCaching When true the side effects are cached when there are no
-     * subscribers, to be emitted later upon first subscription.
-     * On by default.
+     * @property sideEffectBufferSize Defines how many side effects can be buffered before the container suspends. If you are
+     * sending many side effects and getting out of memory exceptions this can be turned down to suspend the container instead.
+     * Unlimited by default.
+     * @property idlingRegistry The registry used by the container for signalling idling for UI tests
      */
     class Settings(
-        val sideEffectCaching: Boolean = true,
+        val sideEffectBufferSize: Int = Channel.UNLIMITED,
         val idlingRegistry: IdlingResource = NoopIdlingResource()
     )
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -56,6 +56,8 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
     /**
      * A [Stream] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (only changed states are emitted) by default.
+     * Emissions come in on the main coroutine dispatcher if installed, with the default dispatcher as the fallback. However,
+     * the connection to the stream has to be manually managed and cancelled when appropriate.
      */
     @Suppress("DEPRECATION")
     @Deprecated("stateStream is deprecated and will be removed in Orbit 1.2.0, use stateFlow instead")
@@ -65,6 +67,8 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
      * A [Stream] of one-off side effects posted from [Builder.sideEffect].
      * Depending on the [Settings] this container has been instantiated with, can support
      * side effect caching when there are no listeners (default).
+     * Emissions come in on the main coroutine dispatcher if installed, with the default dispatcher as the fallback. However,
+     * the connection to the stream has to be manually managed and cancelled when appropriate.
      */
     @Suppress("DEPRECATION")
     @Deprecated("sideEffectStream is deprecated and will be removed in Orbit 1.2.0, use sideEffectFlow instead")

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -35,17 +35,32 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
     val currentState: STATE
 
     /**
+     * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
+     * values (only changed states are emitted) by default.
+     */
+    val stateFlow: Flow<STATE>
+
+    /**
+     * A [Flow] of one-off side effects posted from [Builder.sideEffect].
+     * Depending on the [Settings] this container has been instantiated with, can support
+     * side effect caching when there are no listeners (default).
+     */
+    val sideEffectFlow: Flow<SIDE_EFFECT>
+
+    /**
      * A [Stream] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (only changed states are emitted) by default.
      */
-    val stateStream: Flow<STATE>
+    @Deprecated("stateStream is deprecated, use stateFlow instead")
+    val stateStream: Stream<STATE>
 
     /**
      * A [Stream] of one-off side effects posted from [Builder.sideEffect].
      * Depending on the [Settings] this container has been instantiated with, can support
      * side effect caching when there are no listeners (default).
      */
-    val sideEffectStream: Flow<SIDE_EFFECT>
+    @Deprecated("sideEffectStream is deprecated, use sideEffectFlow instead")
+    val sideEffectStream: Stream<SIDE_EFFECT>
 
     /**
      * Builds and executes an orbit flow using the [Builder] and

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -18,6 +18,7 @@ package com.babylon.orbit2
 
 import com.babylon.orbit2.idling.IdlingResource
 import com.babylon.orbit2.idling.NoopIdlingResource
+import kotlinx.coroutines.flow.Flow
 
 /**
  * The heart of the Orbit MVI system. Represents an MVI container with its input and outputs.
@@ -37,14 +38,14 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
      * A [Stream] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (only changed states are emitted) by default.
      */
-    val stateStream: Stream<STATE>
+    val stateStream: Flow<STATE>
 
     /**
      * A [Stream] of one-off side effects posted from [Builder.sideEffect].
      * Depending on the [Settings] this container has been instantiated with, can support
      * side effect caching when there are no listeners (default).
      */
-    val sideEffectStream: Stream<SIDE_EFFECT>
+    val sideEffectStream: Flow<SIDE_EFFECT>
 
     /**
      * Builds and executes an orbit flow using the [Builder] and

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -48,18 +48,20 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
     val sideEffectFlow: Flow<SIDE_EFFECT>
 
     /**
-     * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
+     * A [Stream] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (only changed states are emitted) by default.
      */
-    @Deprecated("stateStream is deprecated, use stateFlow instead")
+    @Suppress("DEPRECATION")
+    @Deprecated("stateStream is deprecated and will be removed in Orbit 1.2.0, use stateFlow instead")
     val stateStream: Stream<STATE>
 
     /**
-     * A [Flow] of one-off side effects posted from [Builder.sideEffect].
+     * A [Stream] of one-off side effects posted from [Builder.sideEffect].
      * Depending on the [Settings] this container has been instantiated with, can support
      * side effect caching when there are no listeners (default).
      */
-    @Deprecated("sideEffectStream is deprecated, use sideEffectFlow instead")
+    @Suppress("DEPRECATION")
+    @Deprecated("sideEffectStream is deprecated and will be removed in Orbit 1.2.0, use sideEffectFlow instead")
     val sideEffectStream: Stream<SIDE_EFFECT>
 
     /**

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -48,14 +48,14 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
     val sideEffectFlow: Flow<SIDE_EFFECT>
 
     /**
-     * A [Stream] of state updates. Emits the latest state upon subscription and serves only distinct
+     * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (only changed states are emitted) by default.
      */
     @Deprecated("stateStream is deprecated, use stateFlow instead")
     val stateStream: Stream<STATE>
 
     /**
-     * A [Stream] of one-off side effects posted from [Builder.sideEffect].
+     * A [Flow] of one-off side effects posted from [Builder.sideEffect].
      * Depending on the [Settings] this container has been instantiated with, can support
      * side effect caching when there are no listeners (default).
      */

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/LazyCreateContainerDecorator.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/LazyCreateContainerDecorator.kt
@@ -16,7 +16,9 @@
 
 package com.babylon.orbit2
 
-import java.io.Closeable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import java.util.concurrent.atomic.AtomicBoolean
 
 class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
@@ -28,19 +30,16 @@ class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val currentState: STATE
         get() = actual.currentState
 
-    override val stateStream: Stream<STATE>
-        get() = object : Stream<STATE> {
-            override fun observe(lambda: (STATE) -> Unit): Closeable {
-                runOnCreate()
-                return actual.stateStream.observe(lambda)
-            }
+    override val stateStream: Flow<STATE>
+        get() = flow {
+            runOnCreate()
+            emitAll(actual.stateStream)
         }
-    override val sideEffectStream: Stream<SIDE_EFFECT>
-        get() = object : Stream<SIDE_EFFECT> {
-            override fun observe(lambda: (SIDE_EFFECT) -> Unit): Closeable {
-                runOnCreate()
-                return actual.sideEffectStream.observe(lambda)
-            }
+
+    override val sideEffectStream: Flow<SIDE_EFFECT>
+        get() = flow {
+            runOnCreate()
+            emitAll(actual.sideEffectStream)
         }
 
     override fun orbit(

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/LazyCreateContainerDecorator.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/LazyCreateContainerDecorator.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flow
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
 
+@Suppress("OverridingDeprecatedMember", "DEPRECATION")
 class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
     val onCreate: (state: STATE) -> Unit
@@ -47,7 +48,6 @@ class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         get() = object : Stream<STATE> {
             override fun observe(lambda: (STATE) -> Unit): Closeable {
                 runOnCreate()
-                @Suppress("DEPRECATION")
                 return actual.stateStream.observe(lambda)
             }
         }
@@ -56,7 +56,6 @@ class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         get() = object : Stream<SIDE_EFFECT> {
             override fun observe(lambda: (SIDE_EFFECT) -> Unit): Closeable {
                 runOnCreate()
-                @Suppress("DEPRECATION")
                 return actual.sideEffectStream.observe(lambda)
             }
         }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/OrbitDslPlugin.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/OrbitDslPlugin.kt
@@ -17,7 +17,6 @@
 package com.babylon.orbit2
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -33,7 +32,7 @@ interface OrbitDslPlugin {
 
     class ContainerContext<S : Any, SE : Any>(
         val backgroundDispatcher: CoroutineDispatcher,
-        val setState: SendChannel<S>,
+        val setState: (S) -> Unit,
         val postSideEffect: (SE) -> Unit,
         val settings: Container.Settings
     )

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/RealContainer.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/RealContainer.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -69,11 +70,11 @@ open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     override val currentState: STATE
         get() = stateChannel.value
 
-    override val stateStream = stateChannel.asStateStream { currentState }
+    override val stateStream = stateChannel.asFlow()
 
-    override val sideEffectStream: Stream<SIDE_EFFECT> =
+    override val sideEffectStream: Flow<SIDE_EFFECT> =
         if (settings.sideEffectCaching) {
-            sideEffectChannel.asCachingStream(scope)
+            sideEffectChannel.asCachingStream()
         } else {
             sideEffectChannel.asNonCachingStream()
         }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/RealContainer.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/RealContainer.kt
@@ -104,11 +104,11 @@ open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
             }.collect()
     }
 
-    private companion object {
+    companion object {
         // To be replaced by the new API when it hits:
         // https://github.com/Kotlin/kotlinx.coroutines/issues/261
         @Suppress("EXPERIMENTAL_API_USAGE")
-        val DEFAULT_DISPATCHER by lazy {
+        private val DEFAULT_DISPATCHER by lazy {
             newSingleThreadContext("orbit")
         }
     }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Stream.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Stream.kt
@@ -18,15 +18,17 @@ package com.babylon.orbit2
 
 import androidx.annotation.CheckResult
 import java.io.Closeable
+import kotlinx.coroutines.MainCoroutineDispatcher
 
 /**
  * Represents a stream of values.
  *
- * Observing happens on the thread where [observe] is called.
+ * Observing happens on [MainCoroutineDispatcher] if one is installed, otherwise on the default dispatcher.
  *
  * The subscription can be closed using the returned [Closeable]. It is the user's responsibility
  * to manage the lifecycle of the subscription.
  */
+@Deprecated("Stream is deprecated and will be removed in Orbit 1.2.0, use stateFlow instead")
 interface Stream<T> {
 
     @CheckResult

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/BaseDslPluginThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/BaseDslPluginThreadingTest.kt
@@ -37,11 +37,11 @@ internal class BaseDslPluginThreadingTest {
     fun `reducer executes on orbit dispatcher`() {
         val action = fixture<Int>()
         val middleware = BaseDslMiddleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testFlowObserver = middleware.container.stateFlow.test()
 
         middleware.reducer(action)
 
-        testStreamObserver.awaitCount(2)
+        testFlowObserver.awaitCount(2)
         assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
     }
 
@@ -49,11 +49,11 @@ internal class BaseDslPluginThreadingTest {
     fun `transformer executes on background dispatcher`() {
         val action = fixture<Int>()
         val middleware = BaseDslMiddleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testFlowObserver = middleware.container.stateFlow.test()
 
         middleware.transformer(action)
 
-        testStreamObserver.awaitCount(2)
+        testFlowObserver.awaitCount(2)
         assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
     }
 
@@ -61,11 +61,11 @@ internal class BaseDslPluginThreadingTest {
     fun `posting side effects executes on orbit dispatcher`() {
         val action = fixture<Int>()
         val middleware = BaseDslMiddleware()
-        val testStreamObserver = middleware.container.sideEffectStream.test()
+        val testFlowObserver = middleware.container.sideEffectFlow.test()
 
         middleware.postingSideEffect(action)
 
-        testStreamObserver.awaitCount(1)
+        testFlowObserver.awaitCount(1)
         assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
     }
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/BenchmarkTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/BenchmarkTest.kt
@@ -16,36 +16,39 @@
 
 package com.babylon.orbit2
 
+import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
 internal class BenchmarkTest {
 
+    private val fixture = kotlinFixture()
+
     @Test
     fun benchmark() {
-        val middleware = BenchmarkMiddleware()
-        val testStreamObserver = middleware.container.stateStream.test()
         val x = 100_000
+        val middleware = BenchmarkMiddleware(x)
+        val testStreamObserver = middleware.container.stateFlow.test()
 
-        val actions = List(x) {
-            Random.nextInt()
-        }
+        val actions = fixture.asSequence<Int>().distinct().take(100_000)
 
-        GlobalScope.launch {
-            actions.forEach {
-                middleware.reducer(it)
+            GlobalScope.launch {
+                actions.forEach {
+                    middleware.reducer(it)
+                }
             }
-        }
 
         val millisReducing = measureTimeMillis {
-            testStreamObserver.awaitCount(x)
+            middleware.latch.await(10, TimeUnit.SECONDS)
         }
 
+        println(testStreamObserver.values.size)
         println(millisReducing)
         val reduction: Float = millisReducing.toFloat() / x
         println(reduction)
@@ -53,13 +56,15 @@ internal class BenchmarkTest {
 
     private data class TestState(val id: Int)
 
-    private class BenchmarkMiddleware : ContainerHost<TestState, String> {
+    private class BenchmarkMiddleware(count: Int) : ContainerHost<TestState, String> {
         override val container =
             CoroutineScope(Dispatchers.Unconfined).container<TestState, String>(TestState(42))
 
+        val latch = CountDownLatch(count)
+
         fun reducer(action: Int) = orbit {
             reduce {
-                state.copy(id = action)
+                state.copy(id = action).also { latch.countDown() }
             }
         }
     }

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/ContainerLifecycleTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/ContainerLifecycleTest.kt
@@ -30,8 +30,8 @@ internal class ContainerLifecycleTest {
     fun `onCreate is called once after connecting to the container`() {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateStream.test()
-        val testSideEffectObserver = middleware.container.sideEffectStream.test()
+        val testStateObserver = middleware.container.stateFlow.test()
+        val testSideEffectObserver = middleware.container.sideEffectFlow.test()
 
         testStateObserver.awaitCount(1)
         testSideEffectObserver.awaitCount(1)

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/FlowToStreamThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/FlowToStreamThreadingTest.kt
@@ -1,0 +1,78 @@
+package com.babylon.orbit2
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@ExperimentalCoroutinesApi
+internal class FlowToStreamThreadingTest {
+
+    @Nested
+    inner class Default {
+        @Test
+        fun `stream observed on default dispatcher if no main is installed`() {
+            val channel = Channel<Int>()
+            val latch = CountDownLatch(1)
+            var threadName = ""
+
+            channel.receiveAsFlow().asStream().observe {
+                threadName = Thread.currentThread().name
+                latch.countDown()
+            }
+
+            channel.sendBlocking(123)
+
+            latch.await(5, TimeUnit.SECONDS)
+
+            assertThat(threadName).startsWith("Default")
+        }
+    }
+
+    @ObsoleteCoroutinesApi
+    @Nested
+    inner class Main {
+
+        @BeforeEach
+        fun beforeEach() {
+            Dispatchers.setMain(
+                newSingleThreadContext("main")
+            )
+        }
+
+        @AfterEach
+        fun afterEach() {
+            Dispatchers.resetMain()
+        }
+
+        @Test
+        fun `stream observed on main dispatcher if installed`() {
+            val channel = Channel<Int>()
+            val latch = CountDownLatch(1)
+            var threadName = ""
+
+            channel.receiveAsFlow().asStream().observe {
+                threadName = Thread.currentThread().name
+                latch.countDown()
+            }
+
+            channel.sendBlocking(123)
+
+            latch.await(5, TimeUnit.SECONDS)
+
+            assertThat(threadName).startsWith("main")
+        }
+    }
+}

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/ReducerOrderingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/ReducerOrderingTest.kt
@@ -28,7 +28,7 @@ internal class ReducerOrderingTest {
     fun `reductions are applied in sequence`() {
         runBlocking {
             val middleware = ThreeReducersMiddleware()
-            val testStateObserver = middleware.container.stateStream.test()
+            val testStateObserver = middleware.container.stateFlow.test()
             val expectedStates = mutableListOf(
                 TestState(
                     emptyList()

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/ReducerOrderingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/ReducerOrderingTest.kt
@@ -51,7 +51,7 @@ internal class ReducerOrderingTest {
 
             testStateObserver.awaitCount(1120)
 
-            assertThat(testStateObserver.values).containsExactlyElementsOf(expectedStates)
+            assertThat(testStateObserver.values.last()).isEqualTo(expectedStates.last())
         }
     }
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
@@ -19,35 +19,21 @@ package com.babylon.orbit2
 import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import java.util.stream.Stream
 
 internal class SideEffectTest {
 
     private val fixture = kotlinFixture()
 
-    object MulticastTestCases : ArgumentsProvider {
-        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-            Stream.of(
-                Arguments.of(true),
-                Arguments.of(false),
-                Arguments.of(null)
-            )
-    }
-
-    @ParameterizedTest(name = "Caching is {0}")
-    @ArgumentsSource(MulticastTestCases::class)
-    fun `side effects are multicast to all current observers by default`(caching: Boolean?) {
+    @Test
+    fun `side effects are not multicast`() {
         val action = fixture<Int>()
         val action2 = fixture<Int>()
         val action3 = fixture<Int>()
-        val middleware = Middleware(caching)
+        val middleware = Middleware()
 
         val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
         val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
@@ -57,30 +43,22 @@ internal class SideEffectTest {
         middleware.someFlow(action2)
         middleware.someFlow(action3)
 
-        testSideEffectObserver1.awaitCount(3)
-        testSideEffectObserver2.awaitCount(3)
-        testSideEffectObserver3.awaitCount(3)
+        val timeout = 500L
+        testSideEffectObserver1.awaitCount(3, timeout)
+        testSideEffectObserver2.awaitCount(3, timeout)
+        testSideEffectObserver3.awaitCount(3, timeout)
 
-        assertThat(testSideEffectObserver1.values).containsExactly(action, action2, action3)
-        assertThat(testSideEffectObserver2.values).containsExactly(action, action2, action3)
-        assertThat(testSideEffectObserver3.values).containsExactly(action, action2, action3)
+        assertThat(testSideEffectObserver1.values).doesNotContainSequence(action, action2, action3)
+        assertThat(testSideEffectObserver2.values).doesNotContainSequence(action, action2, action3)
+        assertThat(testSideEffectObserver3.values).doesNotContainSequence(action, action2, action3)
     }
 
-    object CachingOnTestCases : ArgumentsProvider {
-        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-            Stream.of(
-                Arguments.of(null),
-                Arguments.of(true)
-            )
-    }
-
-    @ParameterizedTest(name = "Caching is {0}")
-    @ArgumentsSource(CachingOnTestCases::class)
-    fun `when caching is turned on side effects are cached when there are no subscribers`(caching: Boolean?) {
+    @Test
+    fun `side effects are cached when there are no subscribers`() {
         val action = fixture<Int>()
         val action2 = fixture<Int>()
         val action3 = fixture<Int>()
-        val middleware = Middleware(caching)
+        val middleware = Middleware()
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -94,11 +72,11 @@ internal class SideEffectTest {
     }
 
     @Test
-    fun `when caching is turned off side effects are not cached when there are no subscribers`() {
+    fun `consumed side effects are not resent`() {
         val action = fixture<Int>()
         val action2 = fixture<Int>()
         val action3 = fixture<Int>()
-        val middleware = Middleware(false)
+        val middleware = Middleware()
         val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
         middleware.someFlow(action)
@@ -114,13 +92,10 @@ internal class SideEffectTest {
         assertThat(testSideEffectObserver2.values).isEmpty()
     }
 
-    @ParameterizedTest(name = "Caching is {0}")
-    @ArgumentsSource(CachingOnTestCases::class)
-    fun `when caching is turned on only new side effects are emitted when resubscribing`(caching: Boolean?) {
+    @Test
+    fun `only new side effects are emitted when resubscribing`() {
         val action = fixture<Int>()
-        val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
-        val middleware = Middleware(caching)
+        val middleware = Middleware()
 
         val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
@@ -129,72 +104,23 @@ internal class SideEffectTest {
         testSideEffectObserver1.awaitCount(1)
         testSideEffectObserver1.close()
 
-        middleware.someFlow(action2)
-        middleware.someFlow(action3)
+        GlobalScope.launch {
+            repeat(1000) {
+                middleware.someFlow(it)
+            }
+        }
+
+        Thread.sleep(200)
 
         val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
-        testSideEffectObserver2.awaitCount(2)
+        testSideEffectObserver2.awaitCount(1000)
 
         assertThat(testSideEffectObserver1.values).containsExactly(action)
-        assertThat(testSideEffectObserver2.values).containsExactly(action2, action3)
+        assertThat(testSideEffectObserver2.values).containsExactlyElementsOf((0..999).toList())
     }
 
-    @ParameterizedTest(name = "Caching is {0}")
-    @ArgumentsSource(CachingOnTestCases::class)
-    fun `when caching is turned on new subscribers do not get updates if there is already a sub`(
-        caching: Boolean?
-    ) {
-        val action = fixture<Int>()
-        val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
-        val middleware = Middleware(caching)
-
-        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
-
-        middleware.someFlow(action)
-        middleware.someFlow(action2)
-        middleware.someFlow(action3)
-
-        testSideEffectObserver1.awaitCount(3)
-
-        val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
-
-        assertThat(testSideEffectObserver1.values).containsExactly(action, action2, action3)
-        assertThat(testSideEffectObserver2.values).isEmpty()
-    }
-//
-//    @ParameterizedTest(name = "Caching is {0}")
-//    @ArgumentsSource(CachingOnTestCases::class)
-//    fun `side effects are emitted on the thread you subscribe on`(
-//        caching: Boolean?
-//    ) {
-//        val action = fixture<Int>()
-//        val middleware = Middleware(caching)
-//        var subscribingThreadName: String? = null
-//        val countDownLatch = CountDownLatch(1)
-//
-//        runBlocking {
-//
-//            middleware.container.sideEffectFlow.collect {
-//                subscribingThreadName = Thread.currentThread().name
-//                countDownLatch.countDown()
-//            }
-//        }
-//
-//        middleware.someFlow(action)
-//        countDownLatch.await(5, TimeUnit.SECONDS)
-//
-//        assertThat(subscribingThreadName).isEqualTo(Thread.currentThread().name)
-//    }
-
-    private class Middleware(caching: Boolean? = null) : ContainerHost<Unit, Int> {
-        override val container: Container<Unit, Int> =
-            with(CoroutineScope(Dispatchers.Unconfined)) {
-                when (caching) {
-                    null -> container(Unit) // making sure defaults are tested
-                    else -> container(Unit, Container.Settings(caching))
-                }
-            }
+    private class Middleware : ContainerHost<Unit, Int> {
+        override val container: Container<Unit, Int> = CoroutineScope(Dispatchers.Unconfined).container(Unit)
 
         fun someFlow(action: Int) = orbit {
             sideEffect {

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
@@ -19,6 +19,8 @@ package com.babylon.orbit2
 import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -26,6 +28,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
 internal class SideEffectTest {
@@ -162,6 +166,30 @@ internal class SideEffectTest {
         assertThat(testSideEffectObserver1.values).containsExactly(action, action2, action3)
         assertThat(testSideEffectObserver2.values).isEmpty()
     }
+//
+//    @ParameterizedTest(name = "Caching is {0}")
+//    @ArgumentsSource(CachingOnTestCases::class)
+//    fun `side effects are emitted on the thread you subscribe on`(
+//        caching: Boolean?
+//    ) {
+//        val action = fixture<Int>()
+//        val middleware = Middleware(caching)
+//        var subscribingThreadName: String? = null
+//        val countDownLatch = CountDownLatch(1)
+//
+//        runBlocking {
+//
+//            middleware.container.sideEffectStream.collect {
+//                subscribingThreadName = Thread.currentThread().name
+//                countDownLatch.countDown()
+//            }
+//        }
+//
+//        middleware.someFlow(action)
+//        countDownLatch.await(5, TimeUnit.SECONDS)
+//
+//        assertThat(subscribingThreadName).isEqualTo(Thread.currentThread().name)
+//    }
 
     private class Middleware(caching: Boolean? = null) : ContainerHost<Unit, Int> {
         override val container: Container<Unit, Int> =

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/SideEffectTest.kt
@@ -19,8 +19,6 @@ package com.babylon.orbit2
 import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -28,8 +26,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
 internal class SideEffectTest {
@@ -53,9 +49,9 @@ internal class SideEffectTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(caching)
 
-        val testSideEffectObserver1 = middleware.container.sideEffectStream.test()
-        val testSideEffectObserver2 = middleware.container.sideEffectStream.test()
-        val testSideEffectObserver3 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
+        val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
+        val testSideEffectObserver3 = middleware.container.sideEffectFlow.test()
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -90,7 +86,7 @@ internal class SideEffectTest {
         middleware.someFlow(action2)
         middleware.someFlow(action3)
 
-        val testSideEffectObserver1 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
         testSideEffectObserver1.awaitCount(3)
 
@@ -103,7 +99,7 @@ internal class SideEffectTest {
         val action2 = fixture<Int>()
         val action3 = fixture<Int>()
         val middleware = Middleware(false)
-        val testSideEffectObserver1 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -111,7 +107,7 @@ internal class SideEffectTest {
         testSideEffectObserver1.awaitCount(3)
         testSideEffectObserver1.close()
 
-        val testSideEffectObserver2 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
 
         testSideEffectObserver1.awaitCount(3, 10L)
 
@@ -126,7 +122,7 @@ internal class SideEffectTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(caching)
 
-        val testSideEffectObserver1 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
         middleware.someFlow(action)
 
@@ -136,7 +132,7 @@ internal class SideEffectTest {
         middleware.someFlow(action2)
         middleware.someFlow(action3)
 
-        val testSideEffectObserver2 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
         testSideEffectObserver2.awaitCount(2)
 
         assertThat(testSideEffectObserver1.values).containsExactly(action)
@@ -153,7 +149,7 @@ internal class SideEffectTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(caching)
 
-        val testSideEffectObserver1 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver1 = middleware.container.sideEffectFlow.test()
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -161,7 +157,7 @@ internal class SideEffectTest {
 
         testSideEffectObserver1.awaitCount(3)
 
-        val testSideEffectObserver2 = middleware.container.sideEffectStream.test()
+        val testSideEffectObserver2 = middleware.container.sideEffectFlow.test()
 
         assertThat(testSideEffectObserver1.values).containsExactly(action, action2, action3)
         assertThat(testSideEffectObserver2.values).isEmpty()
@@ -179,7 +175,7 @@ internal class SideEffectTest {
 //
 //        runBlocking {
 //
-//            middleware.container.sideEffectStream.collect {
+//            middleware.container.sideEffectFlow.collect {
 //                subscribingThreadName = Thread.currentThread().name
 //                countDownLatch.countDown()
 //            }

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/StateConnectionTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/StateConnectionTest.kt
@@ -19,6 +19,11 @@ package com.babylon.orbit2
 import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/StateConnectionTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/StateConnectionTest.kt
@@ -19,11 +19,6 @@ package com.babylon.orbit2
 import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -35,7 +30,7 @@ internal class StateConnectionTest {
     fun `initial state is emitted on connection`() {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateStream.test()
+        val testStateObserver = middleware.container.stateFlow.test()
 
         testStateObserver.awaitCount(1)
 
@@ -46,12 +41,12 @@ internal class StateConnectionTest {
     fun `latest state is emitted on connection`() {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateStream.test()
+        val testStateObserver = middleware.container.stateFlow.test()
         val action = fixture<Int>()
         middleware.something(action)
         testStateObserver.awaitCount(2) // block until the state is updated
 
-        val testStateObserver2 = middleware.container.stateStream.test()
+        val testStateObserver2 = middleware.container.stateFlow.test()
         testStateObserver2.awaitCount(1)
 
         assertThat(testStateObserver.values).containsExactly(
@@ -78,7 +73,7 @@ internal class StateConnectionTest {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
         val action = fixture<Int>()
-        val testStateObserver = middleware.container.stateStream.test()
+        val testStateObserver = middleware.container.stateFlow.test()
 
         middleware.something(action)
 

--- a/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginBehaviourTest.kt
+++ b/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginBehaviourTest.kt
@@ -22,6 +22,7 @@ import com.babylon.orbit2.OrbitDslPlugins
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
 import com.babylon.orbit2.reduce
+import com.babylon.orbit2.sideEffect
 import com.babylon.orbit2.test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -90,11 +91,11 @@ internal class CoroutineDslPluginBehaviourTest {
         channel.sendBlocking(action + 3)
 
         middleware.assert {
-            states(
-                { TestState(action) },
-                { TestState(action + 1) },
-                { TestState(action + 2) },
-                { TestState(action + 3) }
+            postedSideEffects(
+                action.toString(),
+                (action + 1).toString(),
+                (action + 2).toString(),
+                (action + 3).toString()
             )
         }
     }
@@ -129,8 +130,8 @@ internal class CoroutineDslPluginBehaviourTest {
             transformFlow {
                 hotFlow
             }
-                .reduce {
-                    state.copy(id = event)
+                .sideEffect {
+                    post(event.toString())
                 }
         }
     }

--- a/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
+++ b/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
@@ -44,7 +44,7 @@ internal class CoroutineDslPluginThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.suspend(action)
 
@@ -57,7 +57,7 @@ internal class CoroutineDslPluginThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.flow(action)
 

--- a/orbit-2-livedata/README.md
+++ b/orbit-2-livedata/README.md
@@ -18,12 +18,11 @@ The LiveData plugin provides the following
 [Container](../orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt)
 extension properties:
 
-- [state](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#stateLiveData)
-- [sideEffect](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#sideEffectLiveData)
+- [state](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#state)
+- [sideEffect](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#sideEffect)
 
-Below is the recommended way to subscribe to a
-[Container](../orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt) in
-Android.
+These extensions will be removed in Orbit 1.2.0 due to fundamental
+incompatibility of `LiveData` design with Orbit design goals.
 
 ``` kotlin
 class ExampleActivity: AppCompatActivity() {
@@ -34,8 +33,8 @@ class ExampleActivity: AppCompatActivity() {
     override fun onCreate(savedState: Bundle?) {
         ...
 
-        viewModel.container.stateLiveData.observe(this) {render(it) }
-        viewModel.container.sideEffectLiveData.observe(this) {handleSideEffect(it) }
+        viewModel.container.state.observe(this) {render(it) }
+        viewModel.container.sideEffect.observe(this) {handleSideEffect(it) }
     }
 
     private fun render(state: CalculatorState) {

--- a/orbit-2-livedata/README.md
+++ b/orbit-2-livedata/README.md
@@ -18,8 +18,8 @@ The LiveData plugin provides the following
 [Container](../orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt)
 extension properties:
 
-- [state](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#state)
-- [sideEffect](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#sideEffect)
+- [state](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#stateLiveData)
+- [sideEffect](src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt#sideEffectLiveData)
 
 Below is the recommended way to subscribe to a
 [Container](../orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt) in
@@ -34,8 +34,8 @@ class ExampleActivity: AppCompatActivity() {
     override fun onCreate(savedState: Bundle?) {
         ...
 
-        viewModel.container.state.observe(this, Observer {render(it) })
-        viewModel.container.sideEffect.observe(this, Observer {handleSideEffect(it) })
+        viewModel.container.stateLiveData.observe(this) {render(it) }
+        viewModel.container.sideEffectLiveData.observe(this) {handleSideEffect(it) }
     }
 
     private fun render(state: CalculatorState) {

--- a/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/DelegatingLiveData.kt
+++ b/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/DelegatingLiveData.kt
@@ -35,13 +35,13 @@ internal class DelegatingLiveData<T>(private val flow: Flow<T>) : LiveData<T>() 
     @MainThread
     override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
         // Observe the internal MutableLiveData
-        closeables[observer] = flow.asLiveData().also {
+        closeables[observer] = flow.asLiveData(timeoutInMs = 0L).also {
             it.observe(owner, observer)
         }
     }
 
     override fun observeForever(observer: Observer<in T>) {
-        closeables[observer] = flow.asLiveData().also {
+        closeables[observer] = flow.asLiveData(timeoutInMs = 0L).also {
             it.observeForever(observer)
         }
     }

--- a/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
+++ b/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
@@ -40,7 +40,7 @@ val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.stateLiveData
  * instantiated with, can support side effect caching when there are no listeners (default)
  */
 @Deprecated(
-    message = "Please use sideEffectLiveData instead",
+    message = "Please use sideEffectLiveData instead. Will be removed in Orbit 1.2.0",
     replaceWith = ReplaceWith(
         "sideEffectLiveData"
     )
@@ -53,7 +53,7 @@ val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffect: L
  * values (only changed states are emitted) by default.
  */
 @Deprecated(
-    message = "Please use stateLiveData instead",
+    message = "Please use stateLiveData instead. Will be removed in Orbit 1.2.0",
     replaceWith = ReplaceWith(
         "stateLiveData"
     )

--- a/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
+++ b/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
@@ -17,32 +17,46 @@
 package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.Container.Settings
-import java.io.Closeable
 
 /**
  * A [LiveData] of one-off side effects. Depending on the [Settings] this container has been
  * instantiated with, can support side effect caching when there are no listeners (default)
  */
-val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffect: LiveData<SIDE_EFFECT>
-    get() = DelegatingLiveData(this.sideEffectStream)
+val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffectLiveData: LiveData<SIDE_EFFECT>
+    get() = DelegatingLiveData(this.sideEffectFlow)
 
 /**
  * A [LiveData] of state updates. Emits the latest state upon subscription and serves only distinct
  * values (only changed states are emitted) by default.
  */
+val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.stateLiveData: LiveData<STATE>
+    get() = stateFlow.asLiveData()
+
+/**
+ * A [LiveData] of one-off side effects. Depending on the [Settings] this container has been
+ * instantiated with, can support side effect caching when there are no listeners (default)
+ */
+@Deprecated(
+    message = "Please use sideEffectLiveData instead",
+    replaceWith = ReplaceWith(
+        "sideEffectLiveData"
+    )
+)
+val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffect: LiveData<SIDE_EFFECT>
+    get() = sideEffectLiveData
+
+/**
+ * A [LiveData] of state updates. Emits the latest state upon subscription and serves only distinct
+ * values (only changed states are emitted) by default.
+ */
+@Deprecated(
+    message = "Please use stateLiveData instead",
+    replaceWith = ReplaceWith(
+        "stateLiveData"
+    )
+)
 val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.state: LiveData<STATE>
-    get() = object : LiveData<STATE>(this.currentState) {
-        private var closeable: Closeable? = null
-
-        override fun onActive() {
-            closeable = this@state.stateStream.observe {
-                postValue(it)
-            }
-        }
-
-        override fun onInactive() {
-            closeable?.close()
-        }
-    }
+    get() = stateLiveData

--- a/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
+++ b/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataPlugin.kt
@@ -25,38 +25,18 @@ import com.babylon.orbit2.Container.Settings
  * A [LiveData] of one-off side effects. Depending on the [Settings] this container has been
  * instantiated with, can support side effect caching when there are no listeners (default)
  */
-val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffectLiveData: LiveData<SIDE_EFFECT>
-    get() = DelegatingLiveData(this.sideEffectFlow)
-
-/**
- * A [LiveData] of state updates. Emits the latest state upon subscription and serves only distinct
- * values (only changed states are emitted) by default.
- */
-val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.stateLiveData: LiveData<STATE>
-    get() = stateFlow.asLiveData()
-
-/**
- * A [LiveData] of one-off side effects. Depending on the [Settings] this container has been
- * instantiated with, can support side effect caching when there are no listeners (default)
- */
 @Deprecated(
-    message = "Please use sideEffectLiveData instead. Will be removed in Orbit 1.2.0",
-    replaceWith = ReplaceWith(
-        "sideEffectLiveData"
-    )
+    message = "Please use sideEffectFlow instead. Will be removed in Orbit 1.2.0"
 )
 val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.sideEffect: LiveData<SIDE_EFFECT>
-    get() = sideEffectLiveData
+    get() = DelegatingLiveData(sideEffectFlow)
 
 /**
  * A [LiveData] of state updates. Emits the latest state upon subscription and serves only distinct
  * values (only changed states are emitted) by default.
  */
 @Deprecated(
-    message = "Please use stateLiveData instead. Will be removed in Orbit 1.2.0",
-    replaceWith = ReplaceWith(
-        "stateLiveData"
-    )
+    message = "Please use stateFlow instead. Will be removed in Orbit 1.2.0"
 )
 val <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.state: LiveData<STATE>
-    get() = stateLiveData
+    get() = stateFlow.asLiveData()

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
@@ -18,6 +18,7 @@ package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.Lifecycle
 import com.appmattus.kotlinfixture.kotlinFixture
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -31,6 +32,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -106,7 +108,6 @@ internal class DelegatingLiveDataTest {
 
         val action = fixture<Int>()
         val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
 
         val observer = DelegatingLiveData(channel.consumeAsFlow()).test(mockLifecycleOwner)
 
@@ -118,8 +119,9 @@ internal class DelegatingLiveDataTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_PAUSE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
 
-        channel.sendBlocking(action2)
-        channel.sendBlocking(action3)
+        assertThrows<CancellationException> {
+            channel.sendBlocking(action2)
+        }
 
         assertThat(observer.values).containsExactly(action)
     }

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
@@ -61,7 +61,7 @@ internal class LiveDataDslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val container = scope.createContainer()
-        val sideEffects = container.sideEffectStream.test()
+        val sideEffects = container.sideEffectFlow.test()
         var threadName = ""
 
         container.orbit {

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/SideEffectLiveDataPluginTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/SideEffectLiveDataPluginTest.kt
@@ -24,7 +24,12 @@ import com.babylon.orbit2.container
 import com.babylon.orbit2.sideEffect
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -34,12 +39,23 @@ import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.util.stream.Stream
 
+@ExperimentalCoroutinesApi
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class SideEffectLiveDataPluginTest {
     private val fixture = kotlinFixture()
     private val mockLifecycleOwner = MockLifecycleOwner().also {
         it.dispatchEvent(Lifecycle.Event.ON_CREATE)
         it.dispatchEvent(Lifecycle.Event.ON_START)
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        Dispatchers.resetMain()
     }
 
     internal object MulticastTestCases : ArgumentsProvider {
@@ -65,11 +81,11 @@ internal class SideEffectLiveDataPluginTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
 
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
         val testSideEffectObserver2 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
         val testSideEffectObserver3 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -97,7 +113,7 @@ internal class SideEffectLiveDataPluginTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_CREATE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
 
-        val liveData = middleware.container.sideEffect
+        val liveData = middleware.container.sideEffectLiveData
 
         val testSideEffectObserver1 =
             liveData.test(mockLifecycleOwner)
@@ -140,7 +156,7 @@ internal class SideEffectLiveDataPluginTest {
         middleware.someFlow(action3)
 
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         testSideEffectObserver1.awaitCount(3)
 
@@ -154,7 +170,7 @@ internal class SideEffectLiveDataPluginTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(false)
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -163,7 +179,7 @@ internal class SideEffectLiveDataPluginTest {
         testSideEffectObserver1.close()
 
         val testSideEffectObserver2 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         testSideEffectObserver2.awaitCount(3, 10L)
 
@@ -180,7 +196,7 @@ internal class SideEffectLiveDataPluginTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(caching)
 
-        val liveData = middleware.container.sideEffect
+        val liveData = middleware.container.sideEffectLiveData
 
         val testSideEffectObserver1 = liveData.test(mockLifecycleOwner)
 
@@ -206,7 +222,7 @@ internal class SideEffectLiveDataPluginTest {
         val action3 = fixture<Int>()
         val middleware = Middleware(false)
 
-        val liveData = middleware.container.sideEffect
+        val liveData = middleware.container.sideEffectLiveData
 
         val testSideEffectObserver1 = liveData.test(mockLifecycleOwner)
 
@@ -236,7 +252,7 @@ internal class SideEffectLiveDataPluginTest {
         val middleware = Middleware(caching)
 
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
 
@@ -247,7 +263,7 @@ internal class SideEffectLiveDataPluginTest {
         middleware.someFlow(action3)
 
         val testSideEffectObserver2 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
         testSideEffectObserver2.awaitCount(2)
 
         assertThat(testSideEffectObserver1.values).containsExactly(action)
@@ -262,7 +278,7 @@ internal class SideEffectLiveDataPluginTest {
         val middleware = Middleware(false)
 
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
 
@@ -270,7 +286,7 @@ internal class SideEffectLiveDataPluginTest {
         testSideEffectObserver1.close()
 
         val testSideEffectObserver2 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action2)
         middleware.someFlow(action3)
@@ -288,7 +304,7 @@ internal class SideEffectLiveDataPluginTest {
         val middleware = Middleware(false)
 
         val testSideEffectObserver1 =
-            middleware.container.sideEffect.test(mockLifecycleOwner)
+            middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
         testSideEffectObserver1.awaitCount(1)
@@ -310,7 +326,7 @@ internal class SideEffectLiveDataPluginTest {
         val action2 = fixture<Int>()
         val action3 = fixture<Int>()
         val middleware = Middleware(caching)
-        val liveData = middleware.container.sideEffect
+        val liveData = middleware.container.sideEffectLiveData
 
         val testSideEffectObserver1 = liveData.test(mockLifecycleOwner)
 
@@ -339,7 +355,7 @@ internal class SideEffectLiveDataPluginTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_CREATE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
 
-        val testSideEffectObserver = middleware.container.sideEffect.test(mockLifecycleOwner)
+        val testSideEffectObserver = middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
         middleware.someFlow(action2)
@@ -361,7 +377,7 @@ internal class SideEffectLiveDataPluginTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_CREATE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
 
-        val testSideEffectObserver = middleware.container.sideEffect.test(mockLifecycleOwner)
+        val testSideEffectObserver = middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
 
         middleware.someFlow(action)
         middleware.someFlow(action)
@@ -374,7 +390,7 @@ internal class SideEffectLiveDataPluginTest {
 
     @ParameterizedTest(name = "Caching is {0}")
     @ArgumentsSource(MulticastTestCases::class)
-    fun `something`(
+    fun `side effects are delivered in two different subscriptions`(
         enabled: Boolean?
     ) {
         val action = fixture<Int>()
@@ -383,7 +399,7 @@ internal class SideEffectLiveDataPluginTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_CREATE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
 
-        val testSideEffectObserver = middleware.container.sideEffect.test(mockLifecycleOwner)
+        val testSideEffectObserver = middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
         middleware.someFlow(action)
         testSideEffectObserver.awaitCount(1)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
@@ -391,7 +407,7 @@ internal class SideEffectLiveDataPluginTest {
         assertThat(testSideEffectObserver.values).containsExactly(action)
 
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
-        val testSideEffectObserver2 = middleware.container.sideEffect.test(mockLifecycleOwner)
+        val testSideEffectObserver2 = middleware.container.sideEffectLiveData.test(mockLifecycleOwner)
         middleware.someFlow(action)
         middleware.someFlow(action)
 

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/SideEffectLiveDataPluginTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/SideEffectLiveDataPluginTest.kt
@@ -397,7 +397,6 @@ internal class SideEffectLiveDataPluginTest {
 
         testSideEffectObserver2.awaitCount(2)
 
-
         assertThat(testSideEffectObserver2.values).containsExactly(action, action)
     }
 

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/StateConnectionLiveDataPluginTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/StateConnectionLiveDataPluginTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class StateConnectionLiveDataPluginTest {
@@ -57,7 +58,7 @@ internal class StateConnectionLiveDataPluginTest {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
         val testStateObserver =
-            middleware.container.stateLiveData.test(mockLifecycleOwner)
+            middleware.container.state.test(mockLifecycleOwner)
 
         testStateObserver.awaitCount(1)
 
@@ -69,13 +70,13 @@ internal class StateConnectionLiveDataPluginTest {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
         val testStateObserver =
-            middleware.container.stateLiveData.test(mockLifecycleOwner)
+            middleware.container.state.test(mockLifecycleOwner)
         val action = fixture<Int>()
         middleware.something(action)
         testStateObserver.awaitCount(2) // block until the state is updated
 
         val testStateObserver2 =
-            middleware.container.stateLiveData.test(mockLifecycleOwner)
+            middleware.container.state.test(mockLifecycleOwner)
         testStateObserver2.awaitCount(1)
 
         assertThat(testStateObserver.values).containsExactly(
@@ -93,7 +94,7 @@ internal class StateConnectionLiveDataPluginTest {
     fun `latest state is emitted on connection to the same live data`() {
         val initialState = fixture<TestState>()
         val middleware = Middleware(initialState)
-        val liveData = middleware.container.stateLiveData
+        val liveData = middleware.container.state
         val testStateObserver = liveData.test(mockLifecycleOwner)
         val action = fixture<Int>()
         middleware.something(action)
@@ -129,7 +130,7 @@ internal class StateConnectionLiveDataPluginTest {
             Middleware(initialState)
         val action = fixture<Int>()
         val testStateObserver =
-            middleware.container.stateLiveData.test(mockLifecycleOwner)
+            middleware.container.state.test(mockLifecycleOwner)
 
         middleware.something(action)
 

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/TestLiveDataObserver.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/TestLiveDataObserver.kt
@@ -45,5 +45,15 @@ class TestLiveDataObserver<T>(lifecycleOwner: LifecycleOwner, private val liveDa
         }
     }
 
+    fun awaitNoActiveObservers(timeout: Long = 5000L) {
+        val start = System.currentTimeMillis()
+        while (liveData.hasObservers()) {
+            if (System.currentTimeMillis() - start > timeout) {
+                break
+            }
+            Thread.sleep(10)
+        }
+    }
+
     fun close(): Unit = liveData.removeObserver(observer)
 }

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensions.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensions.kt
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Consume a [Stream] as an RxJava 1 [Observable].
  */
+@Deprecated(
+    message = "Stream is deprecated. Please consider upgrading to RxJava 2 or 3 or using Container.stateFlow or Container.sideEffectFlow.",
+)
 fun <T> Stream<T>.asRx1Observable() = Observable.unsafeCreate<T> { emitter ->
     val unsubscribed = AtomicBoolean(false)
     val closeable = observe {

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensions.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensions.kt
@@ -14,6 +14,8 @@
  *  limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava1
 
 import com.babylon.orbit2.Stream

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensionsKtTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
+@Suppress("DEPRECATION")
 class Rx1StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/Rx1StreamExtensionsKtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava1
 
 import com.appmattus.kotlinfixture.kotlinFixture
@@ -7,7 +9,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
-@Suppress("DEPRECATION")
 class Rx1StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginBehaviourTest.kt
@@ -22,6 +22,7 @@ import com.babylon.orbit2.OrbitDslPlugins
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
 import com.babylon.orbit2.reduce
+import com.babylon.orbit2.sideEffect
 import com.babylon.orbit2.test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -76,11 +77,11 @@ internal class RxJava1DslPluginBehaviourTest {
         middleware.observable(action)
 
         middleware.assert {
-            states(
-                { TestState(action) },
-                { TestState(action + 1) },
-                { TestState(action + 2) },
-                { TestState(action + 3) }
+            postedSideEffects(
+                action.toString(),
+                (action + 1).toString(),
+                (action + 2).toString(),
+                (action + 3).toString()
             )
         }
     }
@@ -113,8 +114,8 @@ internal class RxJava1DslPluginBehaviourTest {
             transformRx1Observable {
                 Observable.just(action, action + 1, action + 2, action + 3)
             }
-                .reduce {
-                    state.copy(id = event)
+                .sideEffect {
+                    post(event.toString())
                 }
         }
     }

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
@@ -44,7 +44,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.single(action)
 
@@ -57,7 +57,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.completable(action)
 
@@ -70,7 +70,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.observable(action)
 

--- a/orbit-2-rxjava2/orbit-2-rxjava2_build.gradle.kts
+++ b/orbit-2-rxjava2/orbit-2-rxjava2_build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(ProjectDependencies.rxJava2)
-    implementation(ProjectDependencies.kotlinCoroutinesRx2)
+    api(ProjectDependencies.kotlinCoroutinesRx2)
 
     api(project(":orbit-2-core"))
 

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensions.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensions.kt
@@ -14,6 +14,8 @@
  *  limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava2
 
 import com.babylon.orbit2.Stream

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensions.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensions.kt
@@ -22,6 +22,11 @@ import io.reactivex.Observable
 /**
  * Consume a [Stream] as an RxJava 2 [Observable].
  */
+@Deprecated(
+    message = "Stream is deprecated. Please use coroutine extensions on " +
+            "Container.stateFlow.asObservable() or Container.sideEffectFlow.asObservable() instead: " +
+            "https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx2",
+)
 fun <T> Stream<T>.asRx2Observable() =
     Observable.create<T> { emitter ->
         val closeable = observe {

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensionsKtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava2
 
 import com.appmattus.kotlinfixture.kotlinFixture
@@ -7,7 +9,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
-@Suppress("DEPRECATION")
 class Rx2StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/Rx2StreamExtensionsKtTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
+@Suppress("DEPRECATION")
 class Rx2StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginBehaviourTest.kt
@@ -22,6 +22,7 @@ import com.babylon.orbit2.OrbitDslPlugins
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
 import com.babylon.orbit2.reduce
+import com.babylon.orbit2.sideEffect
 import com.babylon.orbit2.test
 import io.reactivex.Completable
 import io.reactivex.Maybe
@@ -99,11 +100,11 @@ internal class RxJava2DslPluginBehaviourTest {
         middleware.observable(action)
 
         middleware.assert {
-            states(
-                { TestState(action) },
-                { TestState(action + 1) },
-                { TestState(action + 2) },
-                { TestState(action + 3) }
+            postedSideEffects(
+                action.toString(),
+                (action + 1).toString(),
+                (action + 2).toString(),
+                (action + 3).toString()
             )
         }
     }
@@ -154,8 +155,8 @@ internal class RxJava2DslPluginBehaviourTest {
             transformRx2Observable {
                 Observable.just(action, action + 1, action + 2, action + 3)
             }
-                .reduce {
-                    state.copy(id = event)
+                .sideEffect {
+                    post(event.toString())
                 }
         }
     }

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginDslThreadingTest.kt
@@ -46,7 +46,7 @@ internal class RxJava2DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.single(action)
 
@@ -59,7 +59,7 @@ internal class RxJava2DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.maybe(action)
 
@@ -84,7 +84,7 @@ internal class RxJava2DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.completable(action)
 
@@ -97,7 +97,7 @@ internal class RxJava2DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.observable(action)
 

--- a/orbit-2-rxjava3/orbit-2-rxjava3_build.gradle.kts
+++ b/orbit-2-rxjava3/orbit-2-rxjava3_build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(ProjectDependencies.rxJava3)
-    implementation(ProjectDependencies.kotlinCoroutinesRx3)
+    api(ProjectDependencies.kotlinCoroutinesRx3)
 
     api(project(":orbit-2-core"))
 

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensions.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensions.kt
@@ -14,6 +14,8 @@
  *  limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava3
 
 import com.babylon.orbit2.Stream

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensions.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensions.kt
@@ -22,8 +22,13 @@ import io.reactivex.rxjava3.core.Observable
 /**
  * Consume a [Stream] as an RxJava 3 [Observable].
  */
-fun <T> Stream<T>.asRx3Observable() =
-    Observable.create<T> { emitter ->
+@Deprecated(
+    message = "Stream is deprecated. Please use coroutine extensions on " +
+            "Container.stateFlow.asObservable() or Container.sideEffectFlow.asObservable() instead: " +
+            "https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx3",
+)
+fun <T> Stream<T>.asRx3Observable(): Observable<T> =
+    Observable.create { emitter ->
         val closeable = observe {
             if (!emitter.isDisposed) {
                 emitter.onNext(it)

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensionsKtTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
+@Suppress("DEPRECATION")
 class Rx3StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensionsKtTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/Rx3StreamExtensionsKtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.rxjava3
 
 import com.appmattus.kotlinfixture.kotlinFixture
@@ -7,7 +9,6 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.Closeable
 
-@Suppress("DEPRECATION")
 class Rx3StreamExtensionsKtTest {
 
     private val fixture = kotlinFixture()

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginBehaviourTest.kt
@@ -22,6 +22,7 @@ import com.babylon.orbit2.OrbitDslPlugins
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
 import com.babylon.orbit2.reduce
+import com.babylon.orbit2.sideEffect
 import com.babylon.orbit2.test
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Maybe
@@ -99,11 +100,11 @@ internal class RxJava3DslPluginBehaviourTest {
         middleware.observable(action)
 
         middleware.assert {
-            states(
-                { TestState(action) },
-                { TestState(action + 1) },
-                { TestState(action + 2) },
-                { TestState(action + 3) }
+            postedSideEffects(
+                action.toString(),
+                (action + 1).toString(),
+                (action + 2).toString(),
+                (action + 3).toString()
             )
         }
     }
@@ -154,8 +155,8 @@ internal class RxJava3DslPluginBehaviourTest {
             transformRx3Observable {
                 Observable.just(action, action + 1, action + 2, action + 3)
             }
-                .reduce {
-                    state.copy(id = event)
+                .sideEffect {
+                    post(event.toString())
                 }
         }
     }

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
@@ -46,7 +46,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.single(action)
 
@@ -59,7 +59,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.maybe(action)
 
@@ -84,7 +84,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.completable(action)
 
@@ -97,7 +97,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         val action = fixture<Int>()
 
         val middleware = Middleware()
-        val testStreamObserver = middleware.container.stateStream.test()
+        val testStreamObserver = middleware.container.stateFlow.test()
 
         middleware.observable(action)
 

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
@@ -20,6 +20,11 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -146,8 +151,8 @@ fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> T.as
 
 class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
     val initialState: STATE,
-    val stateObserver: TestStreamObserver<STATE>,
-    val sideEffectObserver: TestStreamObserver<SIDE_EFFECT>
+    val stateObserver: TestFlowObserver<STATE>,
+    val sideEffectObserver: TestFlowObserver<SIDE_EFFECT>
 )
 
 object TestHarness {
@@ -158,3 +163,67 @@ object TestHarness {
  * Allows you to put a [Stream] into test mode.
  */
 fun <T : Any> Stream<T>.test() = TestStreamObserver(this)
+
+fun <T> Flow<T>.test() = TestFlowObserver(this)
+
+/**
+ * Allows you to record all observed values of a flow for easy testing.
+ *
+ * @param flow The flow to observe.
+ */
+class TestFlowObserver<T>(flow: Flow<T>) {
+    private val _values = mutableListOf<T>()
+    private val closeable: Job
+    val values: List<T>
+        get() = _values
+
+    init {
+        closeable = GlobalScope.launch {
+            flow.collect {
+                _values.add(it)
+            }
+        }
+    }
+
+    /**
+     * Awaits until the specified count of elements has been received or the timeout is hit.
+     *
+     * @param count The awaited element count.
+     * @param timeout How long to wait for in milliseconds
+     */
+    fun awaitCount(count: Int, timeout: Long = 5000L) {
+        val start = System.currentTimeMillis()
+        while (values.count() < count) {
+            if (System.currentTimeMillis() - start > timeout) {
+                break
+            }
+            Thread.sleep(AWAIT_TIMEOUT_MS)
+        }
+    }
+
+    /**
+     * Awaits until the specified count of elements has been received or the timeout is hit.
+     *
+     * @param count The awaited element count.
+     * @param timeout How long to wait for in milliseconds
+     */
+    suspend fun awaitCountSuspending(count: Int, timeout: Long = 5000L) {
+        val start = System.currentTimeMillis()
+        while (values.count() < count) {
+            if (System.currentTimeMillis() - start > timeout) {
+                break
+            }
+            delay(AWAIT_TIMEOUT_MS)
+        }
+    }
+
+    /**
+     * Closes the subscription on the underlying stream. No further values will be received after
+     * this call.
+     */
+    fun close(): Unit = closeable.cancel()
+
+    companion object {
+        private const val AWAIT_TIMEOUT_MS = 10L
+    }
+}

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
@@ -68,8 +68,8 @@ inline fun <STATE : Any, SIDE_EFFECT : Any, reified T : ContainerHost<STATE, SID
 
     TestHarness.FIXTURES[spy] = TestFixtures(
         initialState,
-        spy.container.stateStream.test(),
-        spy.container.sideEffectStream.test()
+        spy.container.stateFlow.test(),
+        spy.container.sideEffectFlow.test()
     )
 
     Mockito.clearInvocations(spy)

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
@@ -158,6 +158,7 @@ object TestHarness {
 /**
  * Allows you to put a [Stream] into test mode.
  */
+@Suppress("DEPRECATION")
 fun <T : Any> Stream<T>.test() = TestStreamObserver(this)
 
 /**

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
@@ -20,11 +20,7 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -164,66 +160,7 @@ object TestHarness {
  */
 fun <T : Any> Stream<T>.test() = TestStreamObserver(this)
 
-fun <T> Flow<T>.test() = TestFlowObserver(this)
-
 /**
- * Allows you to record all observed values of a flow for easy testing.
- *
- * @param flow The flow to observe.
+ * Allows you to put a [Flow] into test mode.
  */
-class TestFlowObserver<T>(flow: Flow<T>) {
-    private val _values = mutableListOf<T>()
-    private val closeable: Job
-    val values: List<T>
-        get() = _values
-
-    init {
-        closeable = GlobalScope.launch {
-            flow.collect {
-                _values.add(it)
-            }
-        }
-    }
-
-    /**
-     * Awaits until the specified count of elements has been received or the timeout is hit.
-     *
-     * @param count The awaited element count.
-     * @param timeout How long to wait for in milliseconds
-     */
-    fun awaitCount(count: Int, timeout: Long = 5000L) {
-        val start = System.currentTimeMillis()
-        while (values.count() < count) {
-            if (System.currentTimeMillis() - start > timeout) {
-                break
-            }
-            Thread.sleep(AWAIT_TIMEOUT_MS)
-        }
-    }
-
-    /**
-     * Awaits until the specified count of elements has been received or the timeout is hit.
-     *
-     * @param count The awaited element count.
-     * @param timeout How long to wait for in milliseconds
-     */
-    suspend fun awaitCountSuspending(count: Int, timeout: Long = 5000L) {
-        val start = System.currentTimeMillis()
-        while (values.count() < count) {
-            if (System.currentTimeMillis() - start > timeout) {
-                break
-            }
-            delay(AWAIT_TIMEOUT_MS)
-        }
-    }
-
-    /**
-     * Closes the subscription on the underlying stream. No further values will be received after
-     * this call.
-     */
-    fun close(): Unit = closeable.cancel()
-
-    companion object {
-        private const val AWAIT_TIMEOUT_MS = 10L
-    }
-}
+fun <T> Flow<T>.test() = TestFlowObserver(this)

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/TestFlowObserver.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/TestFlowObserver.kt
@@ -1,0 +1,70 @@
+package com.babylon.orbit2
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/**
+ * Allows you to record all observed values of a flow for easy testing.
+ *
+ * @param flow The flow to observe.
+ */
+class TestFlowObserver<T>(flow: Flow<T>) {
+    private val _values = mutableListOf<T>()
+    private val closeable: Job
+    val values: List<T>
+        get() = _values
+
+    init {
+        closeable = GlobalScope.launch {
+            flow.collect {
+                _values.add(it)
+            }
+        }
+    }
+
+    /**
+     * Awaits until the specified count of elements has been received or the timeout is hit.
+     *
+     * @param count The awaited element count.
+     * @param timeout How long to wait for in milliseconds
+     */
+    fun awaitCount(count: Int, timeout: Long = 5000L) {
+        val start = System.currentTimeMillis()
+        while (values.count() < count) {
+            if (System.currentTimeMillis() - start > timeout) {
+                break
+            }
+            Thread.sleep(AWAIT_TIMEOUT_MS)
+        }
+    }
+
+    /**
+     * Awaits until the specified count of elements has been received or the timeout is hit.
+     *
+     * @param count The awaited element count.
+     * @param timeout How long to wait for in milliseconds
+     */
+    suspend fun awaitCountSuspending(count: Int, timeout: Long = 5000L) {
+        val start = System.currentTimeMillis()
+        while (values.count() < count) {
+            if (System.currentTimeMillis() - start > timeout) {
+                break
+            }
+            delay(AWAIT_TIMEOUT_MS)
+        }
+    }
+
+    /**
+     * Closes the subscription on the underlying stream. No further values will be received after
+     * this call.
+     */
+    fun close(): Unit = closeable.cancel()
+
+    companion object {
+        private const val AWAIT_TIMEOUT_MS = 10L
+    }
+}

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/TestStreamObserver.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/TestStreamObserver.kt
@@ -24,6 +24,7 @@ import java.io.Closeable
  *
  * @param stream The stream to observe.
  */
+@Suppress("DEPRECATION")
 class TestStreamObserver<T>(stream: Stream<T>) {
     private val _values = mutableListOf<T>()
     private val closeable: Closeable

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -172,6 +172,7 @@ class OrbitTestingTest {
         fun `fails if first emitted state does not match expected`(testCase: BlockingModeTests) {
             val testSubject = StateTestMiddleware().test(
                 initialState = State(),
+                isolateFlow = false,
                 blocking = testCase.blocking
             )
             val action = fixture<Int>()
@@ -201,6 +202,7 @@ class OrbitTestingTest {
         fun `fails if second emitted state does not match expected`(testCase: BlockingModeTests) {
             val testSubject = StateTestMiddleware().test(
                 initialState = State(),
+                isolateFlow = false,
                 blocking = testCase.blocking
             )
             val action = fixture<Int>()
@@ -230,6 +232,7 @@ class OrbitTestingTest {
         fun `fails if expected states are out of order`(testCase: BlockingModeTests) {
             val testSubject = StateTestMiddleware().test(
                 initialState = State(),
+                isolateFlow = false,
                 blocking = testCase.blocking
             )
             val action = fixture<Int>()

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -81,6 +81,14 @@ class OrbitTestingTest {
             testSubject.something(action)
             testSubject.something(action2)
 
+            // Await two states before checking
+            testSubject.assert(timeoutMillis = TIMEOUT) {
+                states(
+                    { copy(count = action) },
+                    { copy(count = action2) }
+                )
+            }
+
             val throwable = assertThrows<AssertionError> {
                 testSubject.assert(timeoutMillis = TIMEOUT) {
                     states(

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.EnumSource
 
 class OrbitTestingTest {
     companion object {
-        const val TIMEOUT = 500L
+        const val TIMEOUT = 1000L
     }
 
     val fixture = kotlinFixture()

--- a/orbit-2-viewmodel/src/main/java/com/babylon/orbit2/viewmodel/SavedStateContainerDecorator.kt
+++ b/orbit-2-viewmodel/src/main/java/com/babylon/orbit2/viewmodel/SavedStateContainerDecorator.kt
@@ -14,6 +14,8 @@
  *  limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.babylon.orbit2.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
@@ -26,7 +28,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import java.io.Closeable
 
-@Suppress("OverridingDeprecatedMember", "DEPRECATION")
+@Suppress("OverridingDeprecatedMember")
 internal class SavedStateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
     private val savedStateHandle: SavedStateHandle

--- a/orbit-2-viewmodel/src/main/java/com/babylon/orbit2/viewmodel/SavedStateContainerDecorator.kt
+++ b/orbit-2-viewmodel/src/main/java/com/babylon/orbit2/viewmodel/SavedStateContainerDecorator.kt
@@ -21,14 +21,28 @@ import com.babylon.orbit2.Builder
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerDecorator
 import com.babylon.orbit2.Stream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import java.io.Closeable
 
+@Suppress("OverridingDeprecatedMember", "DEPRECATION")
 internal class SavedStateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
     private val savedStateHandle: SavedStateHandle
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
     override val currentState: STATE
         get() = actual.currentState
+
+    override val stateFlow: Flow<STATE>
+        get() = flow {
+            actual.stateFlow.collect {
+                savedStateHandle[SAVED_STATE_KEY] = it
+                emit(it)
+            }
+        }
+    override val sideEffectFlow: Flow<SIDE_EFFECT>
+        get() = actual.sideEffectFlow
 
     override val stateStream: Stream<STATE>
         get() = object : Stream<STATE> {

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
@@ -27,6 +27,7 @@ import kotlinx.android.parcel.Parcelize
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+@Suppress("DEPRECATION")
 class ViewModelExtensionsKtTest {
     private val fixture = kotlinFixture()
 
@@ -52,12 +53,29 @@ class ViewModelExtensionsKtTest {
     }
 
     @Test
-    fun `Modified state is saved in the saved state handle`() {
+    fun `Modified state is saved in the saved state handle for stateStream`() {
         val initialState = fixture<TestState>()
         val something = fixture<Int>()
         val savedStateHandle = SavedStateHandle()
         val middleware = Middleware(savedStateHandle, initialState)
         val testStateObserver = middleware.container.stateStream.test()
+
+        middleware.something(something)
+
+        testStateObserver.awaitCount(2)
+
+        assertThat(savedStateHandle.get<TestState?>(SAVED_STATE_KEY)).isEqualTo(
+            TestState(something)
+        )
+    }
+
+    @Test
+    fun `Modified state is saved in the saved state handle for stateFlow`() {
+        val initialState = fixture<TestState>()
+        val something = fixture<Int>()
+        val savedStateHandle = SavedStateHandle()
+        val middleware = Middleware(savedStateHandle, initialState)
+        val testStateObserver = middleware.container.stateFlow.test()
 
         middleware.something(something)
 

--- a/samples/orbit-2-calculator/orbit-2-calculator_build.gradle.kts
+++ b/samples/orbit-2-calculator/orbit-2-calculator_build.gradle.kts
@@ -21,10 +21,10 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         minSdkVersion(21)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         versionCode = 1
         versionName = "1.0"
         applicationId = "com.babylon.orbit2.sample.calculator"
@@ -64,4 +64,5 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
     testImplementation("junit:junit:4.13")
     testImplementation("com.appmattus.fixture:fixture:0.9.5")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9")
 }

--- a/samples/orbit-2-calculator/orbit-2-calculator_build.gradle.kts
+++ b/samples/orbit-2-calculator/orbit-2-calculator_build.gradle.kts
@@ -52,9 +52,11 @@ dependencies {
     implementation(project(":orbit-2-livedata"))
     implementation(project(":orbit-2-viewmodel"))
 
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("androidx.constraintlayout:constraintlayout:2.0.1")
     implementation("com.google.android.material:material:1.2.1")
     implementation("org.koin:koin-androidx-viewmodel:2.1.6")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")
 
     // Testing
     testImplementation(project(":orbit-2-test"))

--- a/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
+++ b/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.babylon.orbit2.ContainerHost
-import com.babylon.orbit2.livedata.state
 import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.reduce
 import com.babylon.orbit2.viewmodel.container

--- a/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
+++ b/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
@@ -20,8 +20,8 @@ import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import com.babylon.orbit2.ContainerHost
-import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.reduce
 import com.babylon.orbit2.viewmodel.container
 import kotlinx.android.parcel.Parcelize
@@ -36,7 +36,7 @@ class CalculatorViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    val state: LiveData<CalculatorState> = host.container.stateLiveData as LiveData<CalculatorState>
+    val state: LiveData<CalculatorState> = host.container.stateFlow.asLiveData() as LiveData<CalculatorState>
 
     fun clear() = host.orbit {
         reduce {

--- a/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
+++ b/samples/orbit-2-calculator/src/main/java/com/babylon/orbit2/sample/calculator/CalculatorViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.livedata.state
+import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.reduce
 import com.babylon.orbit2.viewmodel.container
 import kotlinx.android.parcel.Parcelize
@@ -36,7 +37,7 @@ class CalculatorViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    val state: LiveData<CalculatorState> = host.container.state as LiveData<CalculatorState>
+    val state: LiveData<CalculatorState> = host.container.stateLiveData as LiveData<CalculatorState>
 
     fun clear() = host.orbit {
         reduce {

--- a/samples/orbit-2-calculator/src/test/java/com/babylon/orbit2/sample/calculator/CalculatorViewModelTest.kt
+++ b/samples/orbit-2-calculator/src/test/java/com/babylon/orbit2/sample/calculator/CalculatorViewModelTest.kt
@@ -22,7 +22,13 @@ import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.sample.calculator.livedata.InstantTaskExecutorExtension
 import com.babylon.orbit2.sample.calculator.livedata.MockLifecycleOwner
 import com.babylon.orbit2.sample.calculator.livedata.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -34,14 +40,25 @@ import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.util.stream.Stream
 
+@ExperimentalCoroutinesApi
 @ExtendWith(InstantTaskExecutorExtension::class)
 class CalculatorViewModelTest {
 
-    private val viewModel = CalculatorViewModel(SavedStateHandle())
+    private val viewModel by lazy { CalculatorViewModel(SavedStateHandle()) }
 
     private val mockLifecycleOwner = MockLifecycleOwner().also {
         it.dispatchEvent(Lifecycle.Event.ON_CREATE)
         it.dispatchEvent(Lifecycle.Event.ON_START)
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        Dispatchers.resetMain()
     }
 
     /**

--- a/samples/orbit-2-posts/README.md
+++ b/samples/orbit-2-posts/README.md
@@ -19,7 +19,7 @@ This sample implements a simple master-detail application using
   [PostListFragment](src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt)
   observes and sends to the `NavController`.
 
-- The state is accessed in the fragments through `LiveData`.
+- The state is accessed in the fragments through `Flow`.
 
 - [PostListViewModel](src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt)
   and

--- a/samples/orbit-2-posts/orbit-2-posts_build.gradle.kts
+++ b/samples/orbit-2-posts/orbit-2-posts_build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(project(":orbit-2-core"))
     implementation(project(":orbit-2-coroutines"))
-    implementation(project(":orbit-2-livedata"))
     implementation(project(":orbit-2-viewmodel"))
 
     // UI

--- a/samples/orbit-2-posts/orbit-2-posts_build.gradle.kts
+++ b/samples/orbit-2-posts/orbit-2-posts_build.gradle.kts
@@ -27,10 +27,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         minSdkVersion(21)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         applicationId = "com.babylon.orbit2.sample.posts"
         versionCode = 1
         versionName = "1.0"

--- a/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
+++ b/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
@@ -25,10 +25,9 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.babylon.orbit2.livedata.state
+import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.posts.R
 import com.babylon.orbit2.sample.posts.app.common.SeparatorDecoration
 import com.babylon.orbit2.sample.posts.app.features.postdetails.viewmodel.PostDetailState
@@ -74,7 +73,7 @@ class PostDetailsFragment : Fragment() {
 
         post_comments_list.adapter = adapter
 
-        viewModel.container.state.observe(viewLifecycleOwner, Observer { render(it) })
+        viewModel.container.stateLiveData.observe(viewLifecycleOwner) { render(it) }
     }
 
     private fun render(state: PostDetailState) {

--- a/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
+++ b/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
@@ -25,9 +25,9 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.posts.R
 import com.babylon.orbit2.sample.posts.app.common.SeparatorDecoration
 import com.babylon.orbit2.sample.posts.app.features.postdetails.viewmodel.PostDetailState
@@ -39,6 +39,7 @@ import com.bumptech.glide.request.transition.Transition
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
 import kotlinx.android.synthetic.main.post_details_fragment.*
+import kotlinx.coroutines.flow.collect
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -73,7 +74,9 @@ class PostDetailsFragment : Fragment() {
 
         post_comments_list.adapter = adapter
 
-        viewModel.container.stateLiveData.observe(viewLifecycleOwner) { render(it) }
+        lifecycleScope.launchWhenCreated {
+            viewModel.container.stateFlow.collect { render(it) }
+        }
     }
 
     private fun render(state: PostDetailState) {

--- a/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
+++ b/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
@@ -22,17 +22,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.babylon.orbit2.livedata.sideEffectLiveData
-import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.posts.R
+import com.babylon.orbit2.sample.posts.app.common.NavigationEvent
 import com.babylon.orbit2.sample.posts.app.common.SeparatorDecoration
 import com.babylon.orbit2.sample.posts.app.features.postlist.viewmodel.OpenPostNavigationEvent
+import com.babylon.orbit2.sample.posts.app.features.postlist.viewmodel.PostListState
 import com.babylon.orbit2.sample.posts.app.features.postlist.viewmodel.PostListViewModel
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
 import kotlinx.android.synthetic.main.post_list_fragment.*
+import kotlinx.coroutines.flow.collect
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
 
 class PostListFragment : Fragment() {
@@ -63,18 +65,33 @@ class PostListFragment : Fragment() {
 
         content.adapter = adapter
 
-        viewModel.container.stateLiveData.observe(viewLifecycleOwner) {
-            adapter.update(it.overviews.map { PostListItem(it, viewModel) })
+        lifecycleScope.launchWhenCreated {
+            viewModel.container.stateFlow.collect {
+                reduce(adapter, it)
+            }
+        }
+        lifecycleScope.launchWhenCreated {
+            viewModel.container.sideEffectFlow.collect {
+                sideEffect(it)
+            }
         }
     }
 
-    override fun onStart() {
-        super.onStart()
-        viewModel.container.sideEffectLiveData.observe(viewLifecycleOwner) {
-            when (it) {
-                is OpenPostNavigationEvent ->
-                    findNavController().navigate(PostListFragmentDirections.actionListFragmentToDetailFragment(it.post))
-            }
+    private fun sideEffect(it: NavigationEvent) {
+        when (it) {
+            is OpenPostNavigationEvent ->
+                findNavController().navigate(
+                    PostListFragmentDirections.actionListFragmentToDetailFragment(
+                        it.post
+                    )
+                )
         }
+    }
+
+    private fun reduce(
+        adapter: GroupAdapter<GroupieViewHolder>,
+        it: PostListState
+    ) {
+        adapter.update(it.overviews.map { PostListItem(it, viewModel) })
     }
 }

--- a/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
+++ b/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
@@ -35,25 +35,19 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
 import kotlinx.android.synthetic.main.post_list_fragment.*
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
+import java.io.Closeable
 
 class PostListFragment : Fragment() {
 
     private val viewModel: PostListViewModel by stateViewModel()
+    private var sub: Closeable? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        viewModel.container.sideEffect.observe(
-            viewLifecycleOwner,
-            Observer {
-                when (it) {
-                    is OpenPostNavigationEvent ->
-                        findNavController().navigate(PostListFragmentDirections.actionListFragmentToDetailFragment(it.post))
-                }
-            }
-        )
+
 
         return inflater.inflate(R.layout.post_list_fragment, container, false)
     }
@@ -79,5 +73,20 @@ class PostListFragment : Fragment() {
                 adapter.update(it.overviews.map { PostListItem(it, viewModel) })
             }
         )
+    }
+
+    override fun onStart() {
+        super.onStart()
+        sub = viewModel.container.sideEffectStream.observe {
+                when (it) {
+                    is OpenPostNavigationEvent ->
+                        findNavController().navigate(PostListFragmentDirections.actionListFragmentToDetailFragment(it.post))
+                }
+            }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        sub?.close()
     }
 }

--- a/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
+++ b/samples/orbit-2-posts/src/main/java/com/babylon/orbit2/sample/posts/app/features/postlist/ui/PostListFragment.kt
@@ -25,7 +25,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.babylon.orbit2.livedata.sideEffect
 import com.babylon.orbit2.livedata.state
 import com.babylon.orbit2.sample.posts.R
 import com.babylon.orbit2.sample.posts.app.common.SeparatorDecoration
@@ -47,7 +46,6 @@ class PostListFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-
 
         return inflater.inflate(R.layout.post_list_fragment, container, false)
     }

--- a/samples/orbit-2-stocklist/orbit-2-stocklist_build.gradle.kts
+++ b/samples/orbit-2-stocklist/orbit-2-stocklist_build.gradle.kts
@@ -22,10 +22,10 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         minSdkVersion(21)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         versionCode = 1
         versionName = "1.0"
         applicationId = "com.babylon.orbit2.sample.stocklist"

--- a/samples/orbit-2-stocklist/orbit-2-stocklist_build.gradle.kts
+++ b/samples/orbit-2-stocklist/orbit-2-stocklist_build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation("com.xwray:groupie-viewbinding:2.8.1")
     implementation("org.koin:koin-androidx-viewmodel:2.1.6")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.2.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.desugar}")
 }

--- a/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/detail/ui/DetailFragment.kt
+++ b/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/detail/ui/DetailFragment.kt
@@ -22,9 +22,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
-import com.babylon.orbit2.livedata.state
+import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.stocklist.R
 import com.babylon.orbit2.sample.stocklist.databinding.DetailFragmentBinding
 import com.babylon.orbit2.sample.stocklist.detail.business.DetailViewModel
@@ -55,18 +54,15 @@ class DetailFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         binding.apply {
-            state = detailViewModel.container.state
+            state = detailViewModel.container.stateLiveData
             lifecycleOwner = this@DetailFragment
         }
 
-        detailViewModel.container.state.observe(
-            viewLifecycleOwner,
-            Observer {
-                it.stock?.let { stock ->
-                    animateChange(binding.bid, binding.bidTick, stock.bid, bidRef)
-                    animateChange(binding.ask, binding.askTick, stock.ask, askRef)
-                }
+        detailViewModel.container.stateLiveData.observe(viewLifecycleOwner) {
+            it.stock?.let { stock ->
+                animateChange(binding.bid, binding.bidTick, stock.bid, bidRef)
+                animateChange(binding.ask, binding.askTick, stock.ask, askRef)
             }
-        )
+        }
     }
 }

--- a/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/detail/ui/DetailFragment.kt
+++ b/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/detail/ui/DetailFragment.kt
@@ -22,13 +22,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
-import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.stocklist.R
 import com.babylon.orbit2.sample.stocklist.databinding.DetailFragmentBinding
 import com.babylon.orbit2.sample.stocklist.detail.business.DetailViewModel
 import com.babylon.orbit2.sample.stocklist.list.ui.JobHolder
 import com.babylon.orbit2.sample.stocklist.list.ui.animateChange
+import kotlinx.coroutines.flow.collect
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -54,14 +56,16 @@ class DetailFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         binding.apply {
-            state = detailViewModel.container.stateLiveData
+            state = detailViewModel.container.stateFlow.asLiveData()
             lifecycleOwner = this@DetailFragment
         }
 
-        detailViewModel.container.stateLiveData.observe(viewLifecycleOwner) {
-            it.stock?.let { stock ->
-                animateChange(binding.bid, binding.bidTick, stock.bid, bidRef)
-                animateChange(binding.ask, binding.askTick, stock.ask, askRef)
+        lifecycleScope.launchWhenCreated {
+            detailViewModel.container.stateFlow.collect {
+                it.stock?.let { stock ->
+                    animateChange(binding.bid, binding.bidTick, stock.bid, bidRef)
+                    animateChange(binding.ask, binding.askTick, stock.ask, askRef)
+                }
             }
         }
     }

--- a/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/list/ui/ListFragment.kt
+++ b/samples/orbit-2-stocklist/src/main/java/com/babylon/orbit2/sample/stocklist/list/ui/ListFragment.kt
@@ -22,12 +22,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.babylon.orbit2.livedata.sideEffect
-import com.babylon.orbit2.livedata.state
+import com.babylon.orbit2.livedata.sideEffectLiveData
+import com.babylon.orbit2.livedata.stateLiveData
 import com.babylon.orbit2.sample.stocklist.R
 import com.babylon.orbit2.sample.stocklist.databinding.ListFragmentBinding
 import com.babylon.orbit2.sample.stocklist.list.business.ListSideEffect
@@ -63,25 +62,19 @@ class ListFragment : Fragment() {
             addItemDecoration(DividerItemDecoration(context, LinearLayoutManager.VERTICAL))
         }
 
-        listViewModel.container.state.observe(
-            viewLifecycleOwner,
-            Observer {
-                val items = it.stocks.map { stock ->
-                    StockItem(stock, listViewModel)
-                }
-
-                groupAdapter.update(items)
+        listViewModel.container.stateLiveData.observe(viewLifecycleOwner) {
+            val items = it.stocks.map { stock ->
+                StockItem(stock, listViewModel)
             }
-        )
 
-        listViewModel.container.sideEffect.observe(
-            viewLifecycleOwner,
-            Observer {
-                when (it) {
-                    is ListSideEffect.NavigateToDetail ->
-                        findNavController().navigate(ListFragmentDirections.actionListFragmentToDetailFragment(it.itemName))
-                }
+            groupAdapter.update(items)
+        }
+
+        listViewModel.container.sideEffectLiveData.observe(viewLifecycleOwner) {
+            when (it) {
+                is ListSideEffect.NavigateToDetail ->
+                    findNavController().navigate(ListFragmentDirections.actionListFragmentToDetailFragment(it.itemName))
             }
-        )
+        }
     }
 }


### PR DESCRIPTION
#121 made us run extra checks on our connection methods and `Stream` turned out to not behave as expected threading-wise. We've discussed next steps and decided to deprecate the `Stream` interface and expose `Flow`s instead. This decision did not come lightly because we wanted the core module to be agnostic of the internal implementation (i.e. not expose coroutines).

Our reasoning behind why we did this in the end:
- The refactoring has greatly simplified the internals. Previously there was a lot of tricky and hard to maintain code just to wrap internals into `Stream` interfaces.
- Coroutine flows are these days effectively part of the core Kotlin language. We don't gain much by hiding them.
- We want you to have control over the thread you observe on. This can be done easily with `Flow`

The change had a cascading effect through all of our connection methods which required a `Stream`as the base connection method. A good amount of changes were required, but we have kept backwards compatibility for the next release.

Full list of changes:
- Added `stateFlow` and `sideEffectFlow` to `Container`. Flows are now the recommended way to connect to Orbit.
- `sideEffectFlow` supports only one collector to ensure predictable side effect caching behaviour. Multicasting is still possible but this is down through the user's conscious decision of modifying the underlying stream using `broadcast` (which disables caching).
- Deprecated `stateStream` and `sideEffectStream` on `Container`
- Deprecated extensions to turn `Stream` into other types like RxJava `Observable`
- Deprecated `Container.state` and `Container.sideEffect` `LiveData` extensions.
- Made `stateStream` and `sideEffectStream` more predictable by observing on the Main thread where possible