### PR TITLE
Enabled strict API mode for all library modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,11 +102,22 @@ subprojects {
     plugins.withId("com.android.application") {
         apply(from = "$rootDir/gradle/scripts/jacoco-android.gradle.kts")
     }
-    plugins.withId("org.jetbrains.kotlin.jvm") {
+    plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper> {
         apply(from = "$rootDir/gradle/scripts/jacoco.gradle.kts")
         apply(from = "$rootDir/gradle/scripts/bintray.gradle.kts")
+        configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
+            // for strict mode
+            explicitApi()
+        }
     }
     plugins.withId("com.android.library") {
+        plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper> {
+            println(this)
+            configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
+                // for strict mode
+                explicitApi()
+            }
+        }
         apply(from = "$rootDir/gradle/scripts/jacoco-android.gradle.kts")
         apply(from = "$rootDir/gradle/scripts/bintray.gradle.kts")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,6 @@ subprojects {
     }
     plugins.withId("com.android.library") {
         plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper> {
-            println(this)
             configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
                 // for strict mode
                 explicitApi()

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/Container.kt
@@ -32,17 +32,17 @@ import kotlinx.coroutines.flow.Flow
  * @param SIDE_EFFECT The type of side effects posted by this container. Can be [Nothing] if this
  * container never posts side effects.
  */
-interface Container<STATE : Any, SIDE_EFFECT : Any> {
+public interface Container<STATE : Any, SIDE_EFFECT : Any> {
     /**
      * The container's current state.
      */
-    val currentState: STATE
+    public val currentState: STATE
 
     /**
      * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (through equality comparison).
      */
-    val stateFlow: Flow<STATE>
+    public val stateFlow: Flow<STATE>
 
     /**
      * A [Flow] of one-off side effects posted from [Container]. Caches side effects when there are no collectors.
@@ -54,14 +54,14 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
      * If your particular use case requires multi-casting use `broadcast` on this [Flow], but be aware that caching will not work for the
      * resulting `BroadcastChannel`.
      */
-    val sideEffectFlow: Flow<SIDE_EFFECT>
+    public val sideEffectFlow: Flow<SIDE_EFFECT>
 
     /**
      * Executes an orbit flow. The flows are built in the [ContainerHost] using your chosen syntax.
      *
      * @param orbitFlow lambda returning the suspend function representing the flow
      */
-    fun orbit(orbitFlow: suspend OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>.() -> Unit)
+    public fun orbit(orbitFlow: suspend OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>.() -> Unit)
 
     /**
      * Represents additional settings to create the container with.
@@ -73,10 +73,10 @@ interface Container<STATE : Any, SIDE_EFFECT : Any> {
      * @property orbitDispatcher The dispatcher used for handling incoming [orbit] flows
      * @property backgroundDispatcher The dispatcher used for background operations (depending on syntax)
      */
-    class Settings(
-        val sideEffectBufferSize: Int = Channel.UNLIMITED,
-        val idlingRegistry: IdlingResource = NoopIdlingResource(),
-        val orbitDispatcher: CoroutineDispatcher = Dispatchers.Default,
-        val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    public class Settings(
+        public val sideEffectBufferSize: Int = Channel.UNLIMITED,
+        public val idlingRegistry: IdlingResource = NoopIdlingResource(),
+        public val orbitDispatcher: CoroutineDispatcher = Dispatchers.Default,
+        public val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO,
     )
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/ContainerDecorator.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/ContainerDecorator.kt
@@ -23,9 +23,9 @@ package com.babylon.orbit2
  * @param SIDE_EFFECT The type of side effects posted by this container. Can be [Nothing] if this
  * container never posts side effects.
  */
-interface ContainerDecorator<STATE : Any, SIDE_EFFECT : Any> : Container<STATE, SIDE_EFFECT> {
+public interface ContainerDecorator<STATE : Any, SIDE_EFFECT : Any> : Container<STATE, SIDE_EFFECT> {
     /**
      * The wrapped container.
      */
-    val actual: Container<STATE, SIDE_EFFECT>
+    public val actual: Container<STATE, SIDE_EFFECT>
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/ContainerHost.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/ContainerHost.kt
@@ -23,7 +23,7 @@ package com.babylon.orbit2
  * Extension functions `intent` and `orbit` are provided as a convenient way of launching orbit
  * flows on the container.
  */
-interface ContainerHost<STATE : Any, SIDE_EFFECT : Any> {
+public interface ContainerHost<STATE : Any, SIDE_EFFECT : Any> {
     /**
      * The orbit [Container] instance.
      *
@@ -33,5 +33,5 @@ interface ContainerHost<STATE : Any, SIDE_EFFECT : Any> {
      * override val container = scope.container<MyState, MySideEffect>(initialState)
      * ```
      */
-    val container: Container<STATE, SIDE_EFFECT>
+    public val container: Container<STATE, SIDE_EFFECT>
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/CoroutineScopeExtensions.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/CoroutineScopeExtensions.kt
@@ -16,6 +16,7 @@
 
 package com.babylon.orbit2
 
+import com.babylon.orbit2.Container.Settings
 import com.babylon.orbit2.internal.LazyCreateContainerDecorator
 import com.babylon.orbit2.internal.RealContainer
 import kotlinx.coroutines.CoroutineScope
@@ -29,9 +30,9 @@ import kotlinx.coroutines.CoroutineScope
  * executed in a lazy manner when the container is first interacted with in any way.
  * @return A [Container] implementation
  */
-fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
+public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
     initialState: STATE,
-    settings: Container.Settings = Container.Settings(),
+    settings: Settings = Settings(),
     onCreate: ((state: STATE) -> Unit)? = null
 ): Container<STATE, SIDE_EFFECT> =
     if (onCreate == null) {

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/idling/IdlingResource.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/idling/IdlingResource.kt
@@ -1,7 +1,7 @@
 package com.babylon.orbit2.idling
 
-interface IdlingResource {
-    fun increment()
-    fun decrement()
-    fun close()
+public interface IdlingResource {
+    public fun increment()
+    public fun decrement()
+    public fun close()
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/idling/NoopIdlingResource.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/idling/NoopIdlingResource.kt
@@ -1,7 +1,7 @@
 package com.babylon.orbit2.idling
 
-class NoopIdlingResource : IdlingResource {
-    override fun increment() = Unit
-    override fun decrement() = Unit
-    override fun close() = Unit
+public class NoopIdlingResource : IdlingResource {
+    override fun increment(): Unit = Unit
+    override fun decrement(): Unit = Unit
+    override fun close(): Unit = Unit
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/idling/OperatorIdlingExtensions.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/idling/OperatorIdlingExtensions.kt
@@ -6,7 +6,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 
-suspend fun <O : Operator<*, *>, T> OrbitDslPlugin.ContainerContext<*, *>.withIdling(operator: O, block: suspend O.() -> T): T {
+public suspend fun <O : Operator<*, *>, T> OrbitDslPlugin.ContainerContext<*, *>.withIdling(
+    operator: O,
+    block: suspend O.() -> T
+): T {
     if (operator.registerIdling) settings.idlingRegistry.increment()
     return block(operator).also {
         if (operator.registerIdling) settings.idlingRegistry.decrement()
@@ -14,7 +17,10 @@ suspend fun <O : Operator<*, *>, T> OrbitDslPlugin.ContainerContext<*, *>.withId
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")
-suspend fun <O : Operator<*, *>, T> OrbitDslPlugin.ContainerContext<*, *>.withIdlingFlow(operator: O, block: suspend O.() -> Flow<T>): Flow<T> {
+public suspend fun <O : Operator<*, *>, T> OrbitDslPlugin.ContainerContext<*, *>.withIdlingFlow(
+    operator: O,
+    block: suspend O.() -> Flow<T>
+): Flow<T> {
     return block(operator)
         .onStart { if (operator.registerIdling) settings.idlingRegistry.increment() }
         .onCompletion { if (operator.registerIdling) settings.idlingRegistry.decrement() }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/idling/SimpleIdlingExtensions.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/idling/SimpleIdlingExtensions.kt
@@ -2,7 +2,7 @@ package com.babylon.orbit2.idling
 
 import com.babylon.orbit2.syntax.strict.OrbitDslPlugin
 
-suspend fun <STATE : Any, SIDE_EFFECT : Any> OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>.withIdling(
+public suspend fun <STATE : Any, SIDE_EFFECT : Any> OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>.withIdling(
     registerIdling: Boolean,
     block: suspend OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>.() -> Unit
 ) {

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/internal/LazyCreateContainerDecorator.kt
@@ -24,9 +24,9 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import java.util.concurrent.atomic.AtomicBoolean
 
-class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
+public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
-    val onCreate: (state: STATE) -> Unit
+    public val onCreate: (state: STATE) -> Unit
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
     private val created = AtomicBoolean(false)
 

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/internal/RealContainer.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/internal/RealContainer.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -32,7 +33,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 @Suppress("EXPERIMENTAL_API_USAGE")
-open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
+public open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     initialState: STATE,
     parentScope: CoroutineScope,
     private val settings: Container.Settings
@@ -44,12 +45,12 @@ open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     private val internalStateFlow = MutableStateFlow(initialState)
     override val currentState: STATE
         get() = internalStateFlow.value
-    override val stateFlow = internalStateFlow
+    override val stateFlow: Flow<STATE> = internalStateFlow
 
     private val sideEffectChannel = Channel<SIDE_EFFECT>(settings.sideEffectBufferSize)
-    override val sideEffectFlow = sideEffectChannel.receiveAsFlow()
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectChannel.receiveAsFlow()
 
-    protected val pluginContext = OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT>(
+    protected val pluginContext: OrbitDslPlugin.ContainerContext<STATE, SIDE_EFFECT> = OrbitDslPlugin.ContainerContext(
         settings = settings,
         postSideEffect = { sideEffectChannel.send(it) },
         getState = {

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/Operator.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/Operator.kt
@@ -16,6 +16,6 @@
 
 package com.babylon.orbit2.syntax
 
-interface Operator<S : Any, E> {
-    val registerIdling: Boolean
+public interface Operator<S : Any, E> {
+    public val registerIdling: Boolean
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/Orbit2Dsl.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/Orbit2Dsl.kt
@@ -17,4 +17,4 @@
 package com.babylon.orbit2.syntax
 
 @DslMarker
-annotation class Orbit2Dsl
+public annotation class Orbit2Dsl

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleContext.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleContext.kt
@@ -24,6 +24,6 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
  * @property state The current state of the container
  */
 @Orbit2Dsl
-interface SimpleContext<STATE : Any> {
-    val state: STATE
+public interface SimpleContext<STATE : Any> {
+    public val state: STATE
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleSyntax.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleSyntax.kt
@@ -20,10 +20,10 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
 import com.babylon.orbit2.syntax.strict.OrbitDslPlugin
 
 @Orbit2Dsl
-class SimpleSyntax<S : Any, SE : Any>(internal val containerContext: OrbitDslPlugin.ContainerContext<S, SE>) {
+public class SimpleSyntax<S : Any, SE : Any>(internal val containerContext: OrbitDslPlugin.ContainerContext<S, SE>) {
 
     /**
      * The current state which can change throughout execution of the orbit block
      */
-    val state: S get() = containerContext.state
+    public val state: S get() = containerContext.state
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleSyntaxExtensions.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/simple/SimpleSyntaxExtensions.kt
@@ -27,7 +27,7 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
  * @param reducer the lambda reducing the current state and incoming event to produce a new state
  */
 @Orbit2Dsl
-suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.reduce(reducer: SimpleContext<S>.() -> S) {
+public suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.reduce(reducer: SimpleContext<S>.() -> S) {
     containerContext.apply {
         reduce { reducerState ->
             object : SimpleContext<S> {
@@ -45,7 +45,7 @@ suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.reduce(reducer: SimpleContex
  * @param sideEffect the side effect to post through the side effect flow
  */
 @Orbit2Dsl
-suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.postSideEffect(sideEffect: SE) {
+public suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.postSideEffect(sideEffect: SE) {
     containerContext.postSideEffect(sideEffect)
 }
 
@@ -56,10 +56,10 @@ suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.postSideEffect(sideEffect: S
  * @param transformer lambda representing the transformer
  */
 @Orbit2Dsl
-fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.intent(
+public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.intent(
     registerIdling: Boolean = true,
     transformer: suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit
-) =
+): Unit =
     container.orbit {
         withIdling(registerIdling) {
             SimpleSyntax(this).transformer()

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/BaseDslPlugin.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/BaseDslPlugin.kt
@@ -46,11 +46,11 @@ internal class Reduce<S : Any, E>(override val registerIdling: Boolean, val bloc
  * @param block the lambda returning a new event given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transform(
+public fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transform(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> E2
 ): Builder<S, SE, E2> {
-    return Builder(stack + Transform(registerIdling, block))
+    return add(Transform(registerIdling, block))
 }
 
 /**
@@ -69,11 +69,11 @@ fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transform(
  * @param block the lambda executing side effects given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E> Builder<S, SE, E>.sideEffect(
+public fun <S : Any, SE : Any, E> Builder<S, SE, E>.sideEffect(
     registerIdling: Boolean = true,
     block: suspend SideEffectContext<S, SE, E>.() -> Unit
 ): Builder<S, SE, E> {
-    return Builder(stack + SideEffect(registerIdling, block))
+    return add(SideEffect(registerIdling, block))
 }
 
 /**
@@ -86,11 +86,11 @@ fun <S : Any, SE : Any, E> Builder<S, SE, E>.sideEffect(
  * @param block the lambda reducing the current state and incoming event to produce a new state
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E> Builder<S, SE, E>.reduce(
+public fun <S : Any, SE : Any, E> Builder<S, SE, E>.reduce(
     registerIdling: Boolean = true,
     block: Context<S, E>.() -> S
 ): Builder<S, SE, E> {
-    return Builder(stack + Reduce(registerIdling, block))
+    return add(Reduce(registerIdling, block))
 }
 
 /**
@@ -100,7 +100,7 @@ fun <S : Any, SE : Any, E> Builder<S, SE, E>.reduce(
  * * [sideEffect]
  * * [reduce]
  */
-object BaseDslPlugin : OrbitDslPlugin {
+public object BaseDslPlugin : OrbitDslPlugin {
     override fun <S : Any, E, SE : Any> apply(
         containerContext: OrbitDslPlugin.ContainerContext<S, SE>,
         flow: Flow<E>,

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/Builder.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/Builder.kt
@@ -22,9 +22,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 @Orbit2Dsl
-class Builder<S : Any, SE : Any, E>(val stack: List<Operator<S, *>> = emptyList()) {
+public class Builder<S : Any, SE : Any, E>(private val stack: List<Operator<S, *>> = emptyList()) {
+
+    public fun <E2> add(operator: Operator<S, E2>): Builder<S, SE, E2> {
+        return Builder(stack + operator)
+    }
+
     @Suppress("UNCHECKED_CAST")
-    fun build(
+    internal fun build(
         pluginContext: OrbitDslPlugin.ContainerContext<S, SE>
     ): Flow<Any?> {
         return stack.fold(flowOf(Unit)) { flow: Flow<Any?>, operator: Operator<S, *> ->

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/Context.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/Context.kt
@@ -26,7 +26,7 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
  * @property event The current event being processed
  */
 @Orbit2Dsl
-interface Context<STATE : Any, EVENT> {
-    val state: STATE
-    val event: EVENT
+public interface Context<STATE : Any, EVENT> {
+    public val state: STATE
+    public val event: EVENT
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/OrbitDslPlugin.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/OrbitDslPlugin.kt
@@ -23,21 +23,21 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Extend this interface to create your own DSL plugin.
  */
-interface OrbitDslPlugin {
-    fun <S : Any, E, SE : Any> apply(
+public interface OrbitDslPlugin {
+    public fun <S : Any, E, SE : Any> apply(
         containerContext: ContainerContext<S, SE>,
         flow: Flow<E>,
         operator: Operator<S, E>,
         createContext: (event: E) -> VolatileContext<S, E>
     ): Flow<Any?>
 
-    class ContainerContext<S : Any, SE : Any>(
-        val settings: Container.Settings,
-        val postSideEffect: suspend (SE) -> Unit,
+    public class ContainerContext<S : Any, SE : Any>(
+        public val settings: Container.Settings,
+        public val postSideEffect: suspend (SE) -> Unit,
         private val getState: () -> S,
-        val reduce: suspend ((S) -> S) -> Unit
+        public val reduce: suspend ((S) -> S) -> Unit
     ) {
-        val state: S
+        public val state: S
             get() = getState()
     }
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/OrbitDslPlugins.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/OrbitDslPlugins.kt
@@ -23,7 +23,7 @@ package com.babylon.orbit2.syntax.strict
  * The base DSL provided by [BaseDslPlugin] does not have to be registered as it is registered
  * implicitly, even after a [reset].
  */
-object OrbitDslPlugins {
+public object OrbitDslPlugins {
 
     internal var plugins: Set<OrbitDslPlugin> = setOf(BaseDslPlugin)
         private set
@@ -33,7 +33,7 @@ object OrbitDslPlugins {
      *
      * @param plugin The DSL plugin to register
      */
-    fun register(plugin: OrbitDslPlugin) {
+    public fun register(plugin: OrbitDslPlugin) {
         if (!plugins.contains(plugin)) {
             plugins = plugins + plugin
         }
@@ -42,7 +42,7 @@ object OrbitDslPlugins {
     /**
      * Clears all registered plugins apart from the [BaseDslPlugin].
      */
-    fun reset() {
+    public fun reset() {
         plugins = setOf(BaseDslPlugin)
     }
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/SideEffectContext.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/SideEffectContext.kt
@@ -8,9 +8,9 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
  * Represents the current context in which a side effect [Operator] is executing.
  */
 @Orbit2Dsl
-interface SideEffectContext<S : Any, SE : Any, E> : Context<S, E> {
+public interface SideEffectContext<S : Any, SE : Any, E> : Context<S, E> {
     /**
      * Posts a side effect to [Container.sideEffectFlow].
      */
-    suspend fun post(event: SE)
+    public suspend fun post(event: SE)
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/StrictSyntax.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/StrictSyntax.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.flow.collect
  * @param init lambda returning the operator chain that represents the flow
  */
 @Orbit2Dsl
-fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.orbit(
+public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.orbit(
     init: Builder<STATE, SIDE_EFFECT, Unit>.() -> Builder<STATE, SIDE_EFFECT, *>
-) = container.orbit {
+): Unit = container.orbit {
     Builder<STATE, SIDE_EFFECT, Unit>()
         .init()
         .build(this)

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/VolatileContext.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/syntax/strict/VolatileContext.kt
@@ -23,9 +23,9 @@ import com.babylon.orbit2.syntax.Orbit2Dsl
  * Represents the current context in which an [Operator] is executing with access to the [volatileState].
  */
 @Orbit2Dsl
-interface VolatileContext<STATE : Any, EVENT> : Context<STATE, EVENT> {
+public interface VolatileContext<STATE : Any, EVENT> : Context<STATE, EVENT> {
     /**
      * The current state which can change throughout execution of the operator
      */
-    fun volatileState(): STATE
+    public fun volatileState(): STATE
 }

--- a/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/CoroutineDslPlugin.kt
+++ b/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/CoroutineDslPlugin.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
  * * [transformSuspend]
  * * [transformFlow]
  */
-object CoroutineDslPlugin : OrbitDslPlugin {
+public object CoroutineDslPlugin : OrbitDslPlugin {
 
     @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_API_USAGE")
     override fun <S : Any, E, SE : Any> apply(

--- a/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/TransformFlow.kt
+++ b/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/TransformFlow.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
 internal class TransformFlow<S : Any, E, E2>(
     override val registerIdling: Boolean,
     val block: suspend VolatileContext<S, E>.() -> Flow<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The flow transformer flat maps incoming [VolatileContext] for every event into coroutine flows.
@@ -38,10 +38,10 @@ internal class TransformFlow<S : Any, E, E2>(
  * @param block the suspending lambda returning a new flow of events given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformFlow(
+public fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformFlow(
     registerIdling: Boolean = false,
     block: suspend VolatileContext<S, E>.() -> Flow<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(CoroutineDslPlugin)
-    return Builder(stack + TransformFlow(registerIdling, block))
+    return add(TransformFlow(registerIdling, block))
 }

--- a/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/TransformSuspend.kt
+++ b/orbit-2-coroutines/src/main/java/com/babylon/orbit2/coroutines/TransformSuspend.kt
@@ -16,9 +16,9 @@
 
 package com.babylon.orbit2.coroutines
 
-import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.Operator
 import com.babylon.orbit2.syntax.Orbit2Dsl
+import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.strict.OrbitDslPlugins
 import com.babylon.orbit2.syntax.strict.VolatileContext
 import kotlinx.coroutines.Dispatchers
@@ -38,10 +38,10 @@ internal class TransformSuspend<S : Any, E, E2>(
  * @param block the suspending lambda returning a new event given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformSuspend(
+public fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformSuspend(
     registerIdling: Boolean = true,
     block: suspend VolatileContext<S, E>.() -> E2
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(CoroutineDslPlugin)
-    return Builder(stack + TransformSuspend(registerIdling, block))
+    return add(TransformSuspend(registerIdling, block))
 }

--- a/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataOperator.kt
+++ b/orbit-2-livedata/src/main/java/com/babylon/orbit2/livedata/LiveDataOperator.kt
@@ -17,16 +17,16 @@
 package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.LiveData
-import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.Operator
 import com.babylon.orbit2.syntax.Orbit2Dsl
+import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.strict.OrbitDslPlugins
 import com.babylon.orbit2.syntax.strict.VolatileContext
 
 internal class LiveDataOperator<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> LiveData<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The transformer flat maps incoming [VolatileContext] for every event into a [LiveData] of
@@ -43,8 +43,8 @@ fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformLiveData(
     block: VolatileContext<S, E>.() -> LiveData<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(LiveDataDslPlugin)
-    return Builder(
-        stack + LiveDataOperator(
+    return add(
+        LiveDataOperator(
             registerIdling,
             block
         )

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Completable.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Completable.kt
@@ -38,10 +38,10 @@ internal class RxJava1Completable<S : Any, E>(
  * @param block the lambda returning a new [Completable] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E> Builder<S, SE, E>.transformRx1Completable(
+public fun <S : Any, SE : Any, E> Builder<S, SE, E>.transformRx1Completable(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Completable
 ): Builder<S, SE, E> {
     OrbitDslPlugins.register(RxJava1DslPlugin)
-    return Builder(stack + RxJava1Completable(registerIdling, block))
+    return add(RxJava1Completable(registerIdling, block))
 }

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1DslPlugin.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1DslPlugin.kt
@@ -48,7 +48,7 @@ import kotlin.coroutines.resumeWithException
  * * [transformRx1Single]
  * * [transformRx1Completable]
  */
-object RxJava1DslPlugin : OrbitDslPlugin {
+public object RxJava1DslPlugin : OrbitDslPlugin {
 
     @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_API_USAGE")
     override fun <S : Any, E, SE : Any> apply(

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Observable.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Observable.kt
@@ -26,7 +26,7 @@ import rx.Observable
 internal class RxJava1Observable<S : Any, E, E2>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Observable<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into an [Observable] of
@@ -38,10 +38,10 @@ internal class RxJava1Observable<S : Any, E, E2>(
  * @param block the lambda returning a new observable of events given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformRx1Observable(
+public fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformRx1Observable(
     registerIdling: Boolean = false,
     block: VolatileContext<S, E>.() -> Observable<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava1DslPlugin)
-    return Builder(stack + RxJava1Observable(registerIdling, block))
+    return add(RxJava1Observable(registerIdling, block))
 }

--- a/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Single.kt
+++ b/orbit-2-rxjava1/src/main/java/com/babylon/orbit2/rxjava1/RxJava1Single.kt
@@ -16,9 +16,9 @@
 
 package com.babylon.orbit2.rxjava1
 
-import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.Operator
 import com.babylon.orbit2.syntax.Orbit2Dsl
+import com.babylon.orbit2.syntax.strict.Builder
 import com.babylon.orbit2.syntax.strict.OrbitDslPlugins
 import com.babylon.orbit2.syntax.strict.VolatileContext
 import rx.Single
@@ -26,7 +26,7 @@ import rx.Single
 internal class RxJava1Single<S : Any, E, E2>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Single<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into a [Single] of
@@ -38,12 +38,10 @@ internal class RxJava1Single<S : Any, E, E2>(
  * @param block the lambda returning a new [Single] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformRx1Single(
+public fun <S : Any, SE : Any, E, E2> Builder<S, SE, E>.transformRx1Single(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Single<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava1DslPlugin)
-    return Builder(
-        stack + RxJava1Single(registerIdling, block)
-    )
+    return add(RxJava1Single(registerIdling, block))
 }

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Completable.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Completable.kt
@@ -38,10 +38,10 @@ internal class RxJava2Completable<S : Any, E : Any>(
  * @param block the lambda returning a new [Completable] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any> Builder<S, SE, E>.transformRx2Completable(
+public fun <S : Any, SE : Any, E : Any> Builder<S, SE, E>.transformRx2Completable(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Completable
 ): Builder<S, SE, E> {
     OrbitDslPlugins.register(RxJava2DslPlugin)
-    return Builder(stack + RxJava2Completable(registerIdling, block))
+    return add(RxJava2Completable(registerIdling, block))
 }

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2DslPlugin.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2DslPlugin.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.withContext
  * * [transformRx2Maybe]
  * * [transformRx2Completable]
  */
-object RxJava2DslPlugin : OrbitDslPlugin {
+public object RxJava2DslPlugin : OrbitDslPlugin {
 
     @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_API_USAGE")
     override fun <S : Any, E, SE : Any> apply(

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Maybe.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Maybe.kt
@@ -26,7 +26,7 @@ import io.reactivex.Maybe
 internal class RxJava2Maybe<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Maybe<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The maybe transformer flat maps incoming [VolatileContext] for every event into a [Maybe] of
@@ -38,10 +38,10 @@ internal class RxJava2Maybe<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new [Maybe] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Maybe(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Maybe(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Maybe<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava2DslPlugin)
-    return Builder(stack + RxJava2Maybe(registerIdling, block))
+    return add(RxJava2Maybe(registerIdling, block))
 }

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Observable.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Observable.kt
@@ -26,7 +26,7 @@ import io.reactivex.Observable
 internal class RxJava2Observable<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Observable<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into an [Observable] of
@@ -38,10 +38,10 @@ internal class RxJava2Observable<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new observable of events given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Observable(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Observable(
     registerIdling: Boolean = false,
     block: VolatileContext<S, E>.() -> Observable<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava2DslPlugin)
-    return Builder(stack + RxJava2Observable(registerIdling, block))
+    return add(RxJava2Observable(registerIdling, block))
 }

--- a/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Single.kt
+++ b/orbit-2-rxjava2/src/main/java/com/babylon/orbit2/rxjava2/RxJava2Single.kt
@@ -26,7 +26,7 @@ import io.reactivex.Single
 internal class RxJava2Single<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Single<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into a [Single] of
@@ -38,10 +38,10 @@ internal class RxJava2Single<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new [Single] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Single(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx2Single(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Single<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava2DslPlugin)
-    return Builder(stack + RxJava2Single(registerIdling, block))
+    return add(RxJava2Single(registerIdling, block))
 }

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Completable.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Completable.kt
@@ -38,10 +38,10 @@ internal class RxJava3Completable<S : Any, E : Any>(
  * @param block the lambda returning a new [Completable] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any> Builder<S, SE, E>.transformRx3Completable(
+public fun <S : Any, SE : Any, E : Any> Builder<S, SE, E>.transformRx3Completable(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Completable
 ): Builder<S, SE, E> {
     OrbitDslPlugins.register(RxJava3DslPlugin)
-    return Builder(stack + RxJava3Completable(registerIdling, block))
+    return add(RxJava3Completable(registerIdling, block))
 }

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3DslPlugin.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3DslPlugin.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.withContext
  * * [transformRx3Maybe]
  * * [transformRx3Completable]
  */
-object RxJava3DslPlugin : OrbitDslPlugin {
+public object RxJava3DslPlugin : OrbitDslPlugin {
 
     @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_API_USAGE")
     override fun <S : Any, E, SE : Any> apply(

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Maybe.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Maybe.kt
@@ -26,7 +26,7 @@ import io.reactivex.rxjava3.core.Maybe
 internal class RxJava3Maybe<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Maybe<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The maybe transformer flat maps incoming [VolatileContext] for every event into a [Maybe] of
@@ -38,10 +38,10 @@ internal class RxJava3Maybe<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new [Maybe] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Maybe(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Maybe(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Maybe<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava3DslPlugin)
-    return Builder(stack + RxJava3Maybe(registerIdling, block))
+    return add(RxJava3Maybe(registerIdling, block))
 }

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Observable.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Observable.kt
@@ -26,7 +26,7 @@ import io.reactivex.rxjava3.core.Observable
 internal class RxJava3Observable<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Observable<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into an [Observable] of
@@ -38,10 +38,10 @@ internal class RxJava3Observable<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new observable of events given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Observable(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Observable(
     registerIdling: Boolean = false,
     block: VolatileContext<S, E>.() -> Observable<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava3DslPlugin)
-    return Builder(stack + RxJava3Observable(registerIdling, block))
+    return add(RxJava3Observable(registerIdling, block))
 }

--- a/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Single.kt
+++ b/orbit-2-rxjava3/src/main/java/com/babylon/orbit2/rxjava3/RxJava3Single.kt
@@ -26,7 +26,7 @@ import io.reactivex.rxjava3.core.Single
 internal class RxJava3Single<S : Any, E, E2 : Any>(
     override val registerIdling: Boolean,
     val block: VolatileContext<S, E>.() -> Single<E2>
-) : Operator<S, E>
+) : Operator<S, E2>
 
 /**
  * The observable transformer flat maps incoming [VolatileContext] for every event into a [Single] of
@@ -38,10 +38,10 @@ internal class RxJava3Single<S : Any, E, E2 : Any>(
  * @param block the lambda returning a new [Single] given the current state and event
  */
 @Orbit2Dsl
-fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Single(
+public fun <S : Any, SE : Any, E : Any, E2 : Any> Builder<S, SE, E>.transformRx3Single(
     registerIdling: Boolean = true,
     block: VolatileContext<S, E>.() -> Single<E2>
 ): Builder<S, SE, E2> {
     OrbitDslPlugins.register(RxJava3DslPlugin)
-    return Builder(stack + RxJava3Single(registerIdling, block))
+    return add(RxJava3Single(registerIdling, block))
 }

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/OrbitVerification.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/OrbitVerification.kt
@@ -16,7 +16,7 @@
 
 package com.babylon.orbit2
 
-class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, SIDE_EFFECT : Any> {
+public class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, SIDE_EFFECT : Any> {
     internal var expectedSideEffects = emptyList<SIDE_EFFECT>()
     internal var expectedStateChanges = emptyList<STATE.() -> STATE>()
     internal var expectedLoopBacks = mutableListOf<Times<HOST, STATE, SIDE_EFFECT>>()
@@ -45,7 +45,7 @@ class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, S
      * @param expectedStateChanges A list of expected state _changes_. Each lambda has the
      * previous state as the receiver.
      */
-    fun states(vararg expectedStateChanges: STATE.() -> STATE) {
+    public fun states(vararg expectedStateChanges: STATE.() -> STATE) {
         this.expectedStateChanges = expectedStateChanges.toList()
     }
 
@@ -54,7 +54,7 @@ class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, S
      *
      * @param expectedSideEffects Expected side effects.
      */
-    fun postedSideEffects(vararg expectedSideEffects: SIDE_EFFECT) {
+    public fun postedSideEffects(vararg expectedSideEffects: SIDE_EFFECT) {
         this.expectedSideEffects = expectedSideEffects.toList()
     }
 
@@ -63,7 +63,7 @@ class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, S
      *
      * @param expectedSideEffects Expected side effects.
      */
-    fun postedSideEffects(expectedSideEffects: Iterable<SIDE_EFFECT>) {
+    public fun postedSideEffects(expectedSideEffects: Iterable<SIDE_EFFECT>) {
         this.expectedSideEffects = expectedSideEffects.toList()
     }
 
@@ -80,7 +80,7 @@ class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, S
      * @param times The number of times the function has been called
      * @param block The function call
      */
-    fun loopBack(times: Int = 1, block: HOST.() -> Unit) {
+    public fun loopBack(times: Int = 1, block: HOST.() -> Unit) {
         this.expectedLoopBacks.add(
             Times(
                 times,

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/Test.kt
@@ -21,7 +21,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -41,7 +40,7 @@ import kotlin.test.assertEquals
  * @param runOnCreate Whether to run the container's create lambda
  * @return Your [ContainerHost] in test mode.
  */
-inline fun <STATE : Any, SIDE_EFFECT : Any, reified T : ContainerHost<STATE, SIDE_EFFECT>> T.test(
+public fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> T.test(
     initialState: STATE,
     isolateFlow: Boolean = true,
     runOnCreate: Boolean = false,
@@ -79,7 +78,7 @@ inline fun <STATE : Any, SIDE_EFFECT : Any, reified T : ContainerHost<STATE, SID
     return spy
 }
 
-fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findOnCreate(): (STATE) -> Unit {
+private fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findOnCreate(): (STATE) -> Unit {
     return (this as? LazyCreateContainerDecorator<STATE, SIDE_EFFECT>)?.onCreate
         ?: (this as? ContainerDecorator<STATE, SIDE_EFFECT>)?.actual?.findOnCreate()
         ?: {}
@@ -93,7 +92,7 @@ fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findOnCreate(
  *
  * @param block The block containing assertions for your [ContainerHost].
  */
-fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> T.assert(
+public fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> T.assert(
     initialState: STATE,
     timeoutMillis: Long = 5000L,
     block: OrbitVerification<T, STATE, SIDE_EFFECT>.() -> Unit = {}
@@ -150,17 +149,12 @@ fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> T.as
     }
 }
 
-class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
+private class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
     val stateObserver: TestFlowObserver<STATE>,
     val sideEffectObserver: TestFlowObserver<SIDE_EFFECT>,
     val blocking: Boolean
 )
 
-object TestHarness {
+private object TestHarness {
     val FIXTURES: MutableMap<ContainerHost<*, *>, TestFixtures<*, *>> = WeakHashMap()
 }
-
-/**
- * Allows you to put a [Flow] into test mode.
- */
-fun <T> Flow<T>.test() = TestFlowObserver(this)

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/TestContainer.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/TestContainer.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
 
-class TestContainer<STATE : Any, SIDE_EFFECT : Any>(
+internal class TestContainer<STATE : Any, SIDE_EFFECT : Any>(
     initialState: STATE,
     private val isolateFlow: Boolean,
     private val blocking: Boolean

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/TestFlowObserver.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/TestFlowObserver.kt
@@ -15,10 +15,10 @@ import kotlinx.coroutines.withContext
  *
  * @param flow The flow to observe.
  */
-class TestFlowObserver<T>(flow: Flow<T>) {
+public class TestFlowObserver<T>(flow: Flow<T>) {
     private val _values = mutableListOf<T>()
     private val scope = CoroutineScope(Dispatchers.Unconfined)
-    val values: List<T>
+    public val values: List<T>
         get() = _values
 
     init {
@@ -35,7 +35,7 @@ class TestFlowObserver<T>(flow: Flow<T>) {
      * @param timeout How long to wait for in milliseconds
      * @param condition The awaited condition
      */
-    suspend fun awaitFor(timeout: Long = 5000L, condition: TestFlowObserver<T>.() -> Boolean) {
+    public suspend fun awaitFor(timeout: Long = 5000L, condition: TestFlowObserver<T>.() -> Boolean) {
         val start = System.currentTimeMillis()
         while (!this.condition()) {
             if (System.currentTimeMillis() - start > timeout) {
@@ -51,7 +51,7 @@ class TestFlowObserver<T>(flow: Flow<T>) {
      * @param count The awaited element count.
      * @param timeout How long to wait for in milliseconds
      */
-    fun awaitCount(count: Int, timeout: Long = 5000L) {
+    public fun awaitCount(count: Int, timeout: Long = 5000L) {
         runBlocking {
             withContext(Dispatchers.Default) {
                 awaitFor(timeout) { values.size == count }
@@ -65,15 +65,20 @@ class TestFlowObserver<T>(flow: Flow<T>) {
      * @param count The awaited element count.
      * @param timeout How long to wait for in milliseconds
      */
-    suspend fun awaitCountSuspending(count: Int, timeout: Long = 5000L) = awaitFor(timeout) { values.size == count }
+    public suspend fun awaitCountSuspending(count: Int, timeout: Long = 5000L): Unit = awaitFor(timeout) { values.size == count }
 
     /**
      * Closes the subscription on the underlying stream. No further values will be received after
      * this call.
      */
-    fun close(): Unit = scope.cancel()
+    public fun close(): Unit = scope.cancel()
 
-    companion object {
+    public companion object {
         private const val AWAIT_TIMEOUT_MS = 10L
     }
 }
+
+/**
+ * Allows you to put a [Flow] into test mode.
+ */
+public fun <T> Flow<T>.test(): TestFlowObserver<T> = TestFlowObserver(this)


### PR DESCRIPTION
Enabled strict API mode on all library modules in order to more easily spot things that could be made private and make sure we don't inadvertently introduce breaking changes.