### PR TITLE
Removed loopback testing support

### DIFF
--- a/orbit-2-test/README.md
+++ b/orbit-2-test/README.md
@@ -25,11 +25,11 @@ Things that we consider important to test:
 - Loopbacks i.e. flow A calling flow B from a `sideEffect`
 - Potentially dependencies being called
 
-The last item on the list is outside of the scope of this library and can be
-easily tested using a mocking framework like `mockito`.
+The last two items on the list are outside of the scope of this library
+and can be easily tested using a mocking framework like `mockito`.
 
-For the first three things we have created utilities that should make them easy
-to test.
+For the first two things we have created utilities that should make them
+easy to test.
 
 ### Additional constraints
 
@@ -97,14 +97,16 @@ The side effect list must match exactly the side effects that are emitted.
 
 ### Asserting loopbacks
 
-```kotlin
-testSubject.assert(State()) {
-    loopBack { doSomething() }
-    loopBack { doSomethingElse(2) }
-}
-```
+Loopbacks can be tested using a mocking framework like `Mockito` which
+will allow you to spy on your `ContainerHost`. It is not the
+responsibility of this library to provide this functionality.
 
-Each loopback is asserted individually.
+```kotlin
+val testSubject = spy(SomeClass())
+
+verify(testSubject).doSomething()
+verify(testSubject).doSomethingElse(2)
+```
 
 ### Putting it all together
 
@@ -112,7 +114,7 @@ Since all of the assertions need to be done within the same `assert` block
 here's what it looks like once we put it together.
 
 ```kotlin
-val testSubject = ExampleViewModel().test(State())
+val testSubject = spy(ExampleViewModel()).test(State()
 
 testSubject.countToFour()
 
@@ -130,8 +132,8 @@ testSubject.assert(State()) {
         Toast(3),
         Toast(4)
     )
-
-    loopBack { doSomething() }
-    loopBack { doSomethingElse(2) }
 }
+
+verify(testSubject).doSomething()
+verify(testSubject).doSomethingElse(2)
 ```

--- a/orbit-2-test/orbit-2-test_build.gradle.kts
+++ b/orbit-2-test/orbit-2-test_build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(ProjectDependencies.kotlinCoroutines)
     implementation(ProjectDependencies.kotlinTest)
-    implementation(ProjectDependencies.mockitoKotlin)
 
     api(project(":orbit-2-core"))
 

--- a/orbit-2-test/src/main/java/com/babylon/orbit2/OrbitVerification.kt
+++ b/orbit-2-test/src/main/java/com/babylon/orbit2/OrbitVerification.kt
@@ -16,10 +16,9 @@
 
 package com.babylon.orbit2
 
-public class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, SIDE_EFFECT : Any> {
+public class OrbitVerification<STATE : Any, SIDE_EFFECT : Any> {
     internal var expectedSideEffects = emptyList<SIDE_EFFECT>()
     internal var expectedStateChanges = emptyList<STATE.() -> STATE>()
-    internal var expectedLoopBacks = mutableListOf<Times<HOST, STATE, SIDE_EFFECT>>()
 
     /**
      * Assert that the expected sequence of state changes has been emitted.
@@ -66,31 +65,4 @@ public class OrbitVerification<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE :
     public fun postedSideEffects(expectedSideEffects: Iterable<SIDE_EFFECT>) {
         this.expectedSideEffects = expectedSideEffects.toList()
     }
-
-    /**
-     * Assert whether other public functions of your host have been called as part of the
-     * execution.
-     *
-     * ``` kotlin
-     * testSubject.assert {
-     *     loopBack { someFunction(123) }
-     * }
-     * ```
-     *
-     * @param times The number of times the function has been called
-     * @param block The function call
-     */
-    public fun loopBack(times: Int = 1, block: HOST.() -> Unit) {
-        this.expectedLoopBacks.add(
-            Times(
-                times,
-                block
-            )
-        )
-    }
-
-    internal data class Times<HOST : ContainerHost<STATE, SIDE_EFFECT>, STATE : Any, SIDE_EFFECT : Any>(
-        val times: Int = 1,
-        val invocation: HOST.() -> Unit
-    )
 }


### PR DESCRIPTION
Loopback testing support will not work on multiplatform due to a Mockito dependency. Having reviewed the functionality we've decided it's not this library's responsibility to provide this functionality - the user can do this sort of testing on their own if they wish. This means we can drop Mockito.