### PR TITLE
Removed kotlinfixture in preparation for multiplatform

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -22,7 +22,6 @@
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="WRAP_ON_TYPING" value="1" />
-      <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -19,6 +19,5 @@ This software uses the following open source works:
 - [AssertJ](https://assertj.github.io/doc/)
 - [Mockito](https://site.mockito.org)
 - [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin)
-- [Kotlin Fixture](https://github.com/appmattus/kotlinfixture/)
 
 See individual sample projects for their notices.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,7 +17,5 @@ This software uses the following open source works:
 - [RxJava](https://github.com/ReactiveX/RxJava)
 - [JUnit](https://junit.org/)
 - [AssertJ](https://assertj.github.io/doc/)
-- [Mockito](https://site.mockito.org)
-- [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin)
 
 See individual sample projects for their notices.

--- a/buildSrc/src/main/kotlin/DependencyManagement.kt
+++ b/buildSrc/src/main/kotlin/DependencyManagement.kt
@@ -44,7 +44,6 @@ object Versions {
     const val mockitoKotlin = "2.2.0"
     const val mockito = "3.6.28"
     const val junitRuntime = "5.7.0"
-    const val kotlinFixture = "1.0.0"
     const val jacoco = "0.8.5"
     const val robolectric = "4.4"
 }
@@ -81,7 +80,6 @@ object ProjectDependencies {
     const val assertJ = "org.assertj:assertj-core:${Versions.assertJ}"
     const val mockitoKotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}"
     const val mockitoInline = "org.mockito:mockito-inline:${Versions.mockito}"
-    const val kotlinFixture = "com.appmattus.fixture:fixture:${Versions.kotlinFixture}"
     const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitRuntime}"
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitRuntime}"
     const val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${Versions.junitRuntime}"
@@ -104,7 +102,6 @@ object GroupedDependencies {
         ProjectDependencies.junitJupiterParams,
         ProjectDependencies.mockitoKotlin,
         ProjectDependencies.mockitoInline,
-        ProjectDependencies.kotlinFixture,
         ProjectDependencies.assertJ
     )
 }

--- a/buildSrc/src/main/kotlin/DependencyManagement.kt
+++ b/buildSrc/src/main/kotlin/DependencyManagement.kt
@@ -100,8 +100,6 @@ object GroupedDependencies {
         ProjectDependencies.junitPlatformConsole,
         ProjectDependencies.junitJupiterApi,
         ProjectDependencies.junitJupiterParams,
-        ProjectDependencies.mockitoKotlin,
-        ProjectDependencies.mockitoInline,
         ProjectDependencies.assertJ
     )
 }

--- a/orbit-2-core/src/main/java/com/babylon/orbit2/internal/RealContainer.kt
+++ b/orbit-2-core/src/main/java/com/babylon/orbit2/internal/RealContainer.kt
@@ -63,7 +63,7 @@ public open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     )
 
     init {
-        scope.produce<Unit> {
+        scope.produce<Unit>(Dispatchers.Unconfined) {
             awaitClose {
                 settings.idlingRegistry.close()
             }

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerLifecycleTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerLifecycleTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.internal
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.container
 import com.babylon.orbit2.syntax.strict.orbit
@@ -26,14 +25,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class ContainerLifecycleTest {
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `onCreate is called once after connecting to the container`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val middleware = Middleware(initialState)
         val testStateObserver = middleware.container.stateFlow.test()
         val testSideEffectObserver = middleware.container.sideEffectFlow.test()
@@ -45,7 +43,7 @@ internal class ContainerLifecycleTest {
         assertThat(testSideEffectObserver.values).containsExactly(initialState.id.toString())
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware(initialState: TestState) : ContainerHost<TestState, String> {
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.internal
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.test
 import kotlinx.coroutines.CoroutineScope
@@ -24,16 +23,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class ContainerThreadingTest {
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `container can process a second action while the first is suspended`() {
-        val container = RealContainer<Int, Nothing>(fixture(), CoroutineScope(Dispatchers.Default), Container.Settings())
+        val container = RealContainer<Int, Nothing>(Random.nextInt(), CoroutineScope(Dispatchers.Default), Container.Settings())
         val observer = container.stateFlow.test()
-        val newState = fixture<Int>()
+        val newState = Random.nextInt()
 
         container.orbit {
             delay(Long.MAX_VALUE)

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/SideEffectTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/SideEffectTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.internal
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.container
 import com.babylon.orbit2.test
@@ -26,10 +25,9 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class SideEffectTest {
-
-    private val fixture = kotlinFixture()
 
     @Test
     fun `side effects are emitted in order`() {
@@ -48,9 +46,9 @@ internal class SideEffectTest {
 
     @Test
     fun `side effects are not multicast`() {
-        val action = fixture<Int>()
-        val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
         val container = CoroutineScope(Dispatchers.Unconfined).container<Unit, Int>(Unit)
 
         val testSideEffectObserver1 = container.sideEffectFlow.test()
@@ -73,9 +71,9 @@ internal class SideEffectTest {
 
     @Test
     fun `side effects are cached when there are no subscribers`() {
-        val action = fixture<Int>()
-        val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
         val container = CoroutineScope(Dispatchers.Unconfined).container<Unit, Int>(Unit)
 
         container.someFlow(action)
@@ -91,9 +89,9 @@ internal class SideEffectTest {
 
     @Test
     fun `consumed side effects are not resent`() {
-        val action = fixture<Int>()
-        val action2 = fixture<Int>()
-        val action3 = fixture<Int>()
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
         val container = CoroutineScope(Dispatchers.Unconfined).container<Unit, Int>(Unit)
         val testSideEffectObserver1 = container.sideEffectFlow.test()
 
@@ -112,7 +110,7 @@ internal class SideEffectTest {
 
     @Test
     fun `only new side effects are emitted when resubscribing`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val container = CoroutineScope(Dispatchers.Unconfined).container<Unit, Int>(Unit)
 
         val testSideEffectObserver1 = container.sideEffectFlow.test()

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/StateTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/StateTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.internal
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.container
 import com.babylon.orbit2.syntax.strict.orbit
@@ -26,14 +25,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class StateTest {
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `initial state is emitted on connection`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val middleware = Middleware(initialState)
         val testStateObserver = middleware.container.stateFlow.test()
 
@@ -44,10 +42,10 @@ internal class StateTest {
 
     @Test
     fun `latest state is emitted on connection`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val middleware = Middleware(initialState)
         val testStateObserver = middleware.container.stateFlow.test()
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         middleware.something(action)
         testStateObserver.awaitCount(2) // block until the state is updated
 
@@ -67,7 +65,7 @@ internal class StateTest {
 
     @Test
     fun `current state is set to the initial state after instantiation`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val middleware = Middleware(initialState)
 
         assertThat(middleware.container.currentState).isEqualTo(initialState)
@@ -75,9 +73,9 @@ internal class StateTest {
 
     @Test
     fun `current state is up to date after modification`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val middleware = Middleware(initialState)
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val testStateObserver = middleware.container.stateFlow.test()
 
         middleware.something(action)
@@ -87,7 +85,7 @@ internal class StateTest {
         assertThat(middleware.container.currentState).isEqualTo(testStateObserver.values.last())
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware(initialState: TestState) : ContainerHost<TestState, String> {
         override val container =

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/BenchmarkTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/BenchmarkTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.simple
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.container
 import com.babylon.orbit2.test
@@ -27,11 +26,10 @@ import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlin.system.measureTimeMillis
 
 internal class BenchmarkTest {
-
-    private val fixture = kotlinFixture()
 
     @Test
     fun benchmark() {
@@ -39,7 +37,7 @@ internal class BenchmarkTest {
         val middleware = BenchmarkMiddleware(x)
         val testFlowObserver = middleware.container.stateFlow.test()
 
-        val actions = fixture.asSequence<Int>().distinct().take(100_000)
+        val actions = List(100_000) { Random.nextInt() }
 
         GlobalScope.launch {
             actions.forEach {

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslBehaviourTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.simple
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -25,15 +24,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class SimpleDslBehaviourTest {
 
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @Test
     fun `reducer produces new states`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.reducer(action)
@@ -47,7 +46,7 @@ internal class SimpleDslBehaviourTest {
 
     @Test
     fun `transformer maps values`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.transformer(action)
@@ -61,7 +60,7 @@ internal class SimpleDslBehaviourTest {
 
     @Test
     fun `posting side effects emit side effects`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.postingSideEffect(action)
@@ -71,7 +70,7 @@ internal class SimpleDslBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class BaseDslMiddleware : ContainerHost<TestState, String> {
         override val container = CoroutineScope(Dispatchers.Unconfined).container<TestState, String>(

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.simple
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -27,6 +26,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
+import kotlin.random.Random
 
 internal class SimpleDslThreadingTest {
 
@@ -35,11 +35,9 @@ internal class SimpleDslThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `reducer executes on orbit dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
         val testFlowObserver = middleware.container.stateFlow.test()
 
@@ -51,7 +49,7 @@ internal class SimpleDslThreadingTest {
 
     @Test
     fun `transformer executes on orbit dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
         val testFlowObserver = middleware.container.stateFlow.test()
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginBehaviourTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.strict
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -24,15 +23,15 @@ import com.babylon.orbit2.test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class BaseDslPluginBehaviourTest {
 
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @Test
     fun `reducer produces new states`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.reducer(action)
@@ -46,7 +45,7 @@ internal class BaseDslPluginBehaviourTest {
 
     @Test
     fun `transformer maps values`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.transformer(action)
@@ -60,7 +59,7 @@ internal class BaseDslPluginBehaviourTest {
 
     @Test
     fun `posting side effects emit side effects`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.postingSideEffect(action)
@@ -72,7 +71,7 @@ internal class BaseDslPluginBehaviourTest {
 
     @Test
     fun `side effect does not post anything if post is not called`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware().test(initialState)
 
         middleware.sideEffect(action)
@@ -92,7 +91,7 @@ internal class BaseDslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class BaseDslMiddleware : ContainerHost<TestState, String> {
         override val container = CoroutineScope(Dispatchers.Unconfined).container<TestState, String>(

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.strict
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -27,6 +26,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
+import kotlin.random.Random
 
 internal class BaseDslPluginThreadingTest {
 
@@ -35,11 +35,9 @@ internal class BaseDslPluginThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `reducer executes on orbit dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
         val testFlowObserver = middleware.container.stateFlow.test()
 
@@ -51,7 +49,7 @@ internal class BaseDslPluginThreadingTest {
 
     @Test
     fun `transformer executes on background dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
         val testFlowObserver = middleware.container.stateFlow.test()
 
@@ -63,7 +61,7 @@ internal class BaseDslPluginThreadingTest {
 
     @Test
     fun `posting side effects executes on orbit dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
         val testFlowObserver = middleware.container.sideEffectFlow.test()
 
@@ -75,7 +73,7 @@ internal class BaseDslPluginThreadingTest {
 
     @Test
     fun `side effect executes on orbit dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = BaseDslMiddleware()
 
         middleware.sideEffect(action)

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BenchmarkTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BenchmarkTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.strict
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.container
 import com.babylon.orbit2.test
@@ -27,11 +26,10 @@ import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlin.system.measureTimeMillis
 
 internal class BenchmarkTest {
-
-    private val fixture = kotlinFixture()
 
     @Test
     fun benchmark() {
@@ -39,7 +37,7 @@ internal class BenchmarkTest {
         val middleware = BenchmarkMiddleware(x)
         val testFlowObserver = middleware.container.stateFlow.test()
 
-        val actions = fixture.asSequence<Int>().distinct().take(100_000)
+        val actions = List(100_000) { Random.nextInt() }
 
         GlobalScope.launch {
             actions.forEach {

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/OrbitDslPluginsTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/OrbitDslPluginsTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.syntax.strict
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.syntax.Operator
 import kotlinx.coroutines.flow.Flow
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
 internal class OrbitDslPluginsTest {
-    val fixture = kotlinFixture()
 
     @AfterEach
     fun afterEach() {

--- a/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginBehaviourTest.kt
+++ b/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.coroutines
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -37,10 +36,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class CoroutineDslPluginBehaviourTest {
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @BeforeEach
     fun beforeEach() {
@@ -49,7 +48,7 @@ internal class CoroutineDslPluginBehaviourTest {
 
     @Test
     fun `suspend transformation maps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.suspend(action)
@@ -63,7 +62,7 @@ internal class CoroutineDslPluginBehaviourTest {
 
     @Test
     fun `flow transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.flow(action)
@@ -80,7 +79,7 @@ internal class CoroutineDslPluginBehaviourTest {
 
     @Test
     fun `hot flow transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val channel = Channel<Int>(100)
         val middleware = Middleware(channel.consumeAsFlow()).test(initialState = initialState, blocking = false)
 
@@ -101,7 +100,7 @@ internal class CoroutineDslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware(val hotFlow: Flow<Int> = emptyFlow()) : ContainerHost<TestState, String> {
 

--- a/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
+++ b/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.coroutines
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -31,6 +30,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.newSingleThreadContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class CoroutineDslPluginThreadingTest {
 
@@ -38,11 +38,9 @@ internal class CoroutineDslPluginThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `suspend transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -55,7 +53,7 @@ internal class CoroutineDslPluginThreadingTest {
 
     @Test
     fun `flow transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
@@ -17,7 +17,6 @@
 package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.Lifecycle
-import com.appmattus.kotlinfixture.kotlinFixture
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,11 +35,11 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import kotlin.random.Random
 
 @ExperimentalCoroutinesApi
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class DelegatingLiveDataTest {
-    private val fixture = kotlinFixture()
     private val mockLifecycleOwner = MockLifecycleOwner().also {
         it.dispatchEvent(Lifecycle.Event.ON_CREATE)
     }
@@ -86,7 +85,7 @@ internal class DelegatingLiveDataTest {
     @EnumSource(TestCase::class)
     fun `observer does not subscribe until onStart`(testCase: TestCase) {
         val channel = Channel<Int>()
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         mockLifecycleOwner.currentState = testCase.state
         val observer = DelegatingLiveData(channel.consumeAsFlow()).test(mockLifecycleOwner)
 
@@ -106,8 +105,8 @@ internal class DelegatingLiveDataTest {
     fun `observer is unsubscribed after the lifecycle is stopped`() {
         val channel = Channel<Int>()
 
-        val action = fixture<Int>()
-        val action2 = fixture<Int>()
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
 
         val observer = DelegatingLiveData(channel.consumeAsFlow()).test(mockLifecycleOwner)
 
@@ -129,7 +128,7 @@ internal class DelegatingLiveDataTest {
     @Test
     fun `the current value cannot be retrieved and returns nulls instead`() {
         val channel = Channel<Int>()
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val liveData = DelegatingLiveData(channel.consumeAsFlow())
         val observer = liveData.test(mockLifecycleOwner)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginBehaviourTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginBehaviourTest.kt
@@ -18,7 +18,6 @@ package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -36,12 +35,12 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.random.Random
 
 @ExperimentalCoroutinesApi
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class LiveDataDslPluginBehaviourTest {
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @BeforeEach
     fun beforeEach() {
@@ -56,9 +55,9 @@ internal class LiveDataDslPluginBehaviourTest {
 
     @Test
     fun `livedata transformation flatmaps`() {
-        val emission = fixture<Int>()
-        val emission2 = fixture<Int>()
-        val emission3 = fixture<Int>()
+        val emission = Random.nextInt()
+        val emission2 = Random.nextInt()
+        val emission3 = Random.nextInt()
         val liveData = MutableLiveData<Int>()
         val middleware = Middleware(liveData).test(initialState = initialState, blocking = false)
         val testObserver = middleware.container.stateFlow.test()
@@ -82,7 +81,7 @@ internal class LiveDataDslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private inner class Middleware(val liveData: LiveData<Int>) : ContainerHost<TestState, String> {
 

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
@@ -17,7 +17,6 @@
 package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.liveData
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.random.Random
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @ExtendWith(InstantTaskExecutorExtension::class)
@@ -45,7 +45,6 @@ internal class LiveDataDslPluginDslThreadingTest {
     }
 
     private val scope = CoroutineScope(Dispatchers.Unconfined)
-    private val fixture = kotlinFixture()
 
     @BeforeEach
     fun beforeEach() {
@@ -60,7 +59,7 @@ internal class LiveDataDslPluginDslThreadingTest {
 
     @Test
     fun `livedata transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val containerHost = scope.createContainerHost()
         val sideEffects = containerHost.container.sideEffectFlow.test()

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava1
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -32,10 +31,10 @@ import org.junit.jupiter.api.Test
 import rx.Completable
 import rx.Observable
 import rx.Single
+import kotlin.random.Random
 
 internal class RxJava1DslPluginBehaviourTest {
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @BeforeEach
     fun beforeEach() {
@@ -44,7 +43,7 @@ internal class RxJava1DslPluginBehaviourTest {
 
     @Test
     fun `single transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.single(action)
@@ -58,7 +57,7 @@ internal class RxJava1DslPluginBehaviourTest {
 
     @Test
     fun `completable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.completable(action)
@@ -72,7 +71,7 @@ internal class RxJava1DslPluginBehaviourTest {
 
     @Test
     fun `observable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.observable(action)
@@ -87,7 +86,7 @@ internal class RxJava1DslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware : ContainerHost<TestState, String> {
 

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava1
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -31,6 +30,7 @@ import org.junit.jupiter.api.Test
 import rx.Completable
 import rx.Observable
 import rx.Single
+import kotlin.random.Random
 
 internal class RxJava1DslPluginDslThreadingTest {
 
@@ -38,11 +38,9 @@ internal class RxJava1DslPluginDslThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `single transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -55,7 +53,7 @@ internal class RxJava1DslPluginDslThreadingTest {
 
     @Test
     fun `completable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -68,7 +66,7 @@ internal class RxJava1DslPluginDslThreadingTest {
 
     @Test
     fun `observable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava2
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -33,10 +32,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class RxJava2DslPluginBehaviourTest {
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @BeforeEach
     fun beforeEach() {
@@ -45,7 +44,7 @@ internal class RxJava2DslPluginBehaviourTest {
 
     @Test
     fun `single transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.single(action)
@@ -59,7 +58,7 @@ internal class RxJava2DslPluginBehaviourTest {
 
     @Test
     fun `non empty maybe transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.maybe(action)
@@ -73,7 +72,7 @@ internal class RxJava2DslPluginBehaviourTest {
 
     @Test
     fun `empty maybe transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.maybeNot(action)
@@ -81,7 +80,7 @@ internal class RxJava2DslPluginBehaviourTest {
 
     @Test
     fun `completable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.completable(action)
@@ -95,7 +94,7 @@ internal class RxJava2DslPluginBehaviourTest {
 
     @Test
     fun `observable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.observable(action)
@@ -110,7 +109,7 @@ internal class RxJava2DslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware : ContainerHost<TestState, String> {
 

--- a/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava2/src/test/java/com/babylon/orbit2/rxjava2/RxJava2DslPluginDslThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava2
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -33,6 +32,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
+import kotlin.random.Random
 
 internal class RxJava2DslPluginDslThreadingTest {
 
@@ -40,11 +40,9 @@ internal class RxJava2DslPluginDslThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `single transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -57,7 +55,7 @@ internal class RxJava2DslPluginDslThreadingTest {
 
     @Test
     fun `non empty maybe transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -70,7 +68,7 @@ internal class RxJava2DslPluginDslThreadingTest {
 
     @Test
     fun `empty maybe transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
 
@@ -82,7 +80,7 @@ internal class RxJava2DslPluginDslThreadingTest {
 
     @Test
     fun `completable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -95,7 +93,7 @@ internal class RxJava2DslPluginDslThreadingTest {
 
     @Test
     fun `observable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginBehaviourTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginBehaviourTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava3
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.assert
 import com.babylon.orbit2.container
@@ -33,10 +32,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 internal class RxJava3DslPluginBehaviourTest {
-    private val fixture = kotlinFixture()
-    private val initialState = fixture<TestState>()
+    private val initialState = TestState()
 
     @BeforeEach
     fun beforeEach() {
@@ -45,7 +44,7 @@ internal class RxJava3DslPluginBehaviourTest {
 
     @Test
     fun `single transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.single(action)
@@ -59,7 +58,7 @@ internal class RxJava3DslPluginBehaviourTest {
 
     @Test
     fun `non empty maybe transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.maybe(action)
@@ -73,7 +72,7 @@ internal class RxJava3DslPluginBehaviourTest {
 
     @Test
     fun `empty maybe transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.maybeNot(action)
@@ -81,7 +80,7 @@ internal class RxJava3DslPluginBehaviourTest {
 
     @Test
     fun `completable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.completable(action)
@@ -95,7 +94,7 @@ internal class RxJava3DslPluginBehaviourTest {
 
     @Test
     fun `observable transformation flatmaps`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
         val middleware = Middleware().test(initialState)
 
         middleware.observable(action)
@@ -110,7 +109,7 @@ internal class RxJava3DslPluginBehaviourTest {
         }
     }
 
-    private data class TestState(val id: Int)
+    private data class TestState(val id: Int = Random.nextInt())
 
     private class Middleware : ContainerHost<TestState, String> {
 

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2.rxjava3
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
@@ -33,6 +32,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
+import kotlin.random.Random
 
 internal class RxJava3DslPluginDslThreadingTest {
 
@@ -40,11 +40,9 @@ internal class RxJava3DslPluginDslThreadingTest {
         const val BACKGROUND_THREAD_PREFIX = "IO"
     }
 
-    private val fixture = kotlinFixture()
-
     @Test
     fun `single transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -57,7 +55,7 @@ internal class RxJava3DslPluginDslThreadingTest {
 
     @Test
     fun `non empty maybe transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -70,7 +68,7 @@ internal class RxJava3DslPluginDslThreadingTest {
 
     @Test
     fun `empty maybe transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
 
@@ -82,7 +80,7 @@ internal class RxJava3DslPluginDslThreadingTest {
 
     @Test
     fun `completable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()
@@ -95,7 +93,7 @@ internal class RxJava3DslPluginDslThreadingTest {
 
     @Test
     fun `observable transformation runs on IO dispatcher`() {
-        val action = fixture<Int>()
+        val action = Random.nextInt()
 
         val middleware = Middleware()
         val testFlowObserver = middleware.container.stateFlow.test()

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -16,7 +16,6 @@
 
 package com.babylon.orbit2
 
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.syntax.strict.sideEffect
@@ -33,13 +32,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import kotlin.random.Random
 
+@ExperimentalStdlibApi
 class OrbitTestingTest {
     companion object {
         const val TIMEOUT = 5000L
     }
-
-    val fixture = kotlinFixture()
 
     @Suppress("unused")
     enum class BlockingModeTests(val blocking: Boolean) {
@@ -47,7 +46,7 @@ class OrbitTestingTest {
         NON_BLOCKING(false)
     }
 
-    private val initialState = fixture<State>()
+    private val initialState = State()
 
     @Nested
     inner class StateTests {
@@ -75,7 +74,7 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val someRandomState = State(fixture())
+            val someRandomState = State()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testStateObserver.awaitCount(1)
@@ -97,8 +96,8 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -122,8 +121,8 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -153,9 +152,9 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
-            val action3 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
+            val action3 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -187,10 +186,10 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
-            val action3 = fixture<Int>()
-            val action4 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
+            val action3 = Random.nextInt()
+            val action4 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -223,9 +222,9 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
-            val action3 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
+            val action3 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -256,9 +255,9 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
-            val action3 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
+            val action3 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -289,8 +288,8 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -321,9 +320,9 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
-            val action3 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
+            val action3 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -351,8 +350,8 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val action = fixture<Int>()
-            val action2 = fixture<Int>()
+            val action = Random.nextInt()
+            val action2 = Random.nextInt()
 
             val testStateObserver = testSubject.container.stateFlow.test()
             testSubject.something(action)
@@ -403,7 +402,7 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val sideEffects = fixture<List<Int>>()
+            val sideEffects = buildList<Int>(Random.nextInt(1, 5)) { Random.nextInt() }
 
             sideEffects.forEach { testSubject.something(it) }
 
@@ -420,8 +419,8 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val sideEffects = fixture<List<Int>>()
-            val sideEffects2 = fixture<List<Int>>()
+            val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
+            val sideEffects2 = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
             sideEffects.forEach { testSubject.something(it) }
 
@@ -517,7 +516,7 @@ class OrbitTestingTest {
         }
     }
 
-    private data class State(val count: Int = 0)
+    private data class State(val count: Int = Random.nextInt())
 
     private interface BogusDependency {
         fun create()

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -552,6 +552,5 @@ class OrbitTestingTest {
         override fun something2() {
             something2CallCount++
         }
-
     }
 }

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.params.provider.EnumSource
 import kotlin.random.Random
 import kotlin.test.assertEquals
 
-@ExperimentalStdlibApi
 class OrbitTestingTest {
     companion object {
         const val TIMEOUT = 5000L
@@ -399,7 +398,7 @@ class OrbitTestingTest {
                 isolateFlow = false,
                 blocking = testCase.blocking
             )
-            val sideEffects = buildList<Int>(Random.nextInt(1, 5)) { Random.nextInt() }
+            val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
             sideEffects.forEach { testSubject.something(it) }
 

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -291,7 +291,7 @@ class AndroidIdlingResourceTest {
     @Test
     fun `cancelling scope removes IdlingResource`() {
         runBlocking {
-            val scope = CoroutineScope(Dispatchers.Unconfined)
+            val scope = CoroutineScope(Dispatchers.Default)
 
             scope.createContainerHost()
 

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -38,6 +38,21 @@ class AndroidIdlingResourceTest {
     @AfterEach
     fun after() {
         scope.cancel()
+
+        // Await for the idling resource to unregister
+        runBlocking {
+            awaitIdlingResourceUnregistration()
+        }
+    }
+
+    private suspend fun awaitIdlingResourceUnregistration(timeoutMillis: Long = 200L) {
+        runCatching {
+            withTimeout(timeoutMillis) {
+                while (IdlingRegistry.getInstance().resources.isNotEmpty()) {
+                    delay(20)
+                }
+            }
+        }
     }
 
     @Test
@@ -297,11 +312,7 @@ class AndroidIdlingResourceTest {
 
             scope.cancel()
 
-            withTimeout(5000L) {
-                while (IdlingRegistry.getInstance().resources.isNotEmpty()) {
-                    delay(20)
-                }
-            }
+            awaitIdlingResourceUnregistration(500L)
 
             assertEquals(0, IdlingRegistry.getInstance().resources.size)
         }

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -312,8 +312,6 @@ class AndroidIdlingResourceTest {
 
             scope.cancel()
 
-            awaitIdlingResourceUnregistration(500L)
-
             assertEquals(0, IdlingRegistry.getInstance().resources.size)
         }
     }

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -30,8 +30,8 @@ class AndroidIdlingResourceTest {
 
     @BeforeEach
     fun before() {
-        IdlingRegistry.getInstance().resources.forEach {
-            IdlingRegistry.getInstance().unregister(it)
+        IdlingRegistry.getInstance().apply {
+            unregister(*resources.toTypedArray())
         }
     }
 
@@ -291,8 +291,6 @@ class AndroidIdlingResourceTest {
     @Test
     fun `cancelling scope removes IdlingResource`() {
         runBlocking {
-            val scope = CoroutineScope(Dispatchers.Default)
-
             scope.createContainerHost()
 
             assertEquals(1, IdlingRegistry.getInstance().resources.size)
@@ -300,7 +298,7 @@ class AndroidIdlingResourceTest {
             scope.cancel()
 
             withTimeout(5000L) {
-                while(IdlingRegistry.getInstance().resources.isNotEmpty()) {
+                while (IdlingRegistry.getInstance().resources.isNotEmpty()) {
                     delay(20)
                 }
             }

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -299,7 +299,7 @@ class AndroidIdlingResourceTest {
 
             scope.cancel()
 
-            delay(50)
+            delay(200)
 
             assertEquals(0, IdlingRegistry.getInstance().resources.size)
         }

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/AndroidIdlingResourceTest.kt
@@ -299,7 +299,11 @@ class AndroidIdlingResourceTest {
 
             scope.cancel()
 
-            delay(200)
+            withTimeout(5000L) {
+                while(IdlingRegistry.getInstance().resources.isNotEmpty()) {
+                    delay(20)
+                }
+            }
 
             assertEquals(0, IdlingRegistry.getInstance().resources.size)
         }

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
@@ -19,7 +19,6 @@ package com.babylon.orbit2.viewmodel
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.appmattus.kotlinfixture.kotlinFixture
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
@@ -27,14 +26,13 @@ import com.babylon.orbit2.test
 import kotlinx.android.parcel.Parcelize
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class ViewModelExtensionsKtTest {
-    private val fixture = kotlinFixture()
-
     @Test
     fun `When saved state is present it is read`() {
-        val initialState = fixture<TestState>()
-        val savedState = fixture<TestState>()
+        val initialState = TestState()
+        val savedState = TestState()
         val savedStateHandle = SavedStateHandle(mapOf(SAVED_STATE_KEY to savedState))
 
         val middleware = Middleware(savedStateHandle, initialState)
@@ -44,7 +42,7 @@ class ViewModelExtensionsKtTest {
 
     @Test
     fun `When saved state is not present the initial state is unchanged`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val savedStateHandle = SavedStateHandle()
 
         val middleware = Middleware(savedStateHandle, initialState)
@@ -54,8 +52,8 @@ class ViewModelExtensionsKtTest {
 
     @Test
     fun `Modified state is saved in the saved state handle for stateFlow`() {
-        val initialState = fixture<TestState>()
-        val something = fixture<Int>()
+        val initialState = TestState()
+        val something = Random.nextInt()
         val savedStateHandle = SavedStateHandle()
         val middleware = Middleware(savedStateHandle, initialState)
         val testStateObserver = middleware.container.stateFlow.test()
@@ -71,8 +69,8 @@ class ViewModelExtensionsKtTest {
 
     @Test
     fun `When saved state is present calls onCreate with true`() {
-        val initialState = fixture<TestState>()
-        val savedState = fixture<TestState>()
+        val initialState = TestState()
+        val savedState = TestState()
         val savedStateHandle = SavedStateHandle(mapOf(SAVED_STATE_KEY to savedState))
         var onCreateState: TestState? = null
 
@@ -88,7 +86,7 @@ class ViewModelExtensionsKtTest {
 
     @Test
     fun `When saved state is not present calls onCreate with false`() {
-        val initialState = fixture<TestState>()
+        val initialState = TestState()
         val savedStateHandle = SavedStateHandle()
         var onCreateState: TestState? = null
 
@@ -121,5 +119,5 @@ class ViewModelExtensionsKtTest {
     }
 
     @Parcelize
-    data class TestState(val id: Int) : Parcelable
+    data class TestState(val id: Int = Random.nextInt()) : Parcelable
 }


### PR DESCRIPTION
KotlinFixture does not currently work on multiplatform, fortunately our usages are simple enough to replace.