### PR TITLE
Replace AssertJ with Kotest due to multiplatform incompatibility

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -16,6 +16,6 @@ This software uses the following open source works:
 - [Detekt](https://github.com/detekt/detekt)
 - [RxJava](https://github.com/ReactiveX/RxJava)
 - [JUnit](https://junit.org/)
-- [AssertJ](https://assertj.github.io/doc/)
+- [Kotest](https://kotest.io)
 
 See individual sample projects for their notices.

--- a/buildSrc/src/main/kotlin/DependencyManagement.kt
+++ b/buildSrc/src/main/kotlin/DependencyManagement.kt
@@ -40,12 +40,10 @@ object Versions {
 
     // Testing
     const val junitPlatform = "1.7.0"
-    const val assertJ = "3.18.1"
-    const val mockitoKotlin = "2.2.0"
-    const val mockito = "3.6.28"
     const val junitRuntime = "5.7.0"
     const val jacoco = "0.8.5"
     const val robolectric = "4.4"
+    const val kotest = "4.3.1"
 }
 
 object ProjectDependencies {
@@ -56,6 +54,7 @@ object ProjectDependencies {
     const val kotlinCoroutinesRx2 = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${Versions.coroutines}"
     const val kotlinCoroutinesRx3 = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:${Versions.coroutines}"
     const val kotlinTest = "org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}"
+    const val kotestAssertions = "io.kotest:kotest-assertions-core:${Versions.kotest}"
 
     // AndroidX
     const val androidxAnnotation = "androidx.annotation:annotation:${Versions.androidxAnnotation}"
@@ -77,9 +76,6 @@ object ProjectDependencies {
     // Test prerequisites
     const val androidxTesting = "androidx.arch.core:core-testing:${Versions.androidxTesting}"
     const val junitPlatformConsole = "org.junit.platform:junit-platform-console:${Versions.junitPlatform}"
-    const val assertJ = "org.assertj:assertj-core:${Versions.assertJ}"
-    const val mockitoKotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}"
-    const val mockitoInline = "org.mockito:mockito-inline:${Versions.mockito}"
     const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitRuntime}"
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitRuntime}"
     const val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${Versions.junitRuntime}"
@@ -100,6 +96,7 @@ object GroupedDependencies {
         ProjectDependencies.junitPlatformConsole,
         ProjectDependencies.junitJupiterApi,
         ProjectDependencies.junitJupiterParams,
-        ProjectDependencies.assertJ
+        ProjectDependencies.kotlinTest,
+        ProjectDependencies.kotestAssertions
     )
 }

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerLifecycleTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerLifecycleTest.kt
@@ -21,9 +21,9 @@ import com.babylon.orbit2.container
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.sideEffect
 import com.babylon.orbit2.test
+import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -39,8 +39,8 @@ internal class ContainerLifecycleTest {
         testStateObserver.awaitCount(1)
         testSideEffectObserver.awaitCount(1)
 
-        assertThat(testStateObserver.values).containsExactly(initialState)
-        assertThat(testSideEffectObserver.values).containsExactly(initialState.id.toString())
+        testStateObserver.values.shouldContainExactly(initialState)
+        testSideEffectObserver.values.shouldContainExactly(initialState.id.toString())
     }
 
     private data class TestState(val id: Int = Random.nextInt())

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ContainerThreadingTest.kt
@@ -18,10 +18,10 @@ package com.babylon.orbit2.internal
 
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.test
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -41,6 +41,6 @@ internal class ContainerThreadingTest {
         }
 
         observer.awaitCount(2)
-        assertThat(container.currentState).isEqualTo(newState)
+        container.currentState.shouldBe(newState)
     }
 }

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ReducerThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/ReducerThreadingTest.kt
@@ -18,12 +18,12 @@ package com.babylon.orbit2.internal
 
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.test
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.EmptyCoroutineContext
@@ -62,7 +62,7 @@ internal class ReducerThreadingTest {
 
             testStateObserver.awaitFor { values.last().ids.size == ITEM_COUNT }
 
-            assertThat(testStateObserver.values.last()).isEqualTo(expectedStates.last())
+            testStateObserver.values.last().shouldBe(expectedStates.last())
         }
     }
 
@@ -99,8 +99,8 @@ internal class ReducerThreadingTest {
 
             testStateObserver.awaitFor { values.last().ids.size == ITEM_COUNT }
 
-            assertThat(testStateObserver.values.last().ids.count { it == 1 }).isEqualTo(ITEM_COUNT / 3)
-            assertThat(testStateObserver.values.last().ids.count { it == 2 }).isEqualTo(ITEM_COUNT / 3)
+            testStateObserver.values.last().ids.count { it == 1 }.shouldBe(ITEM_COUNT / 3)
+            testStateObserver.values.last().ids.count { it == 2 }.shouldBe(ITEM_COUNT / 3)
         }
     }
 

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/SideEffectTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/SideEffectTest.kt
@@ -19,11 +19,13 @@ package com.babylon.orbit2.internal
 import com.babylon.orbit2.Container
 import com.babylon.orbit2.container
 import com.babylon.orbit2.test
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContainExactly
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -41,7 +43,7 @@ internal class SideEffectTest {
 
         testSideEffectObserver1.awaitCount(1000)
 
-        assertThat(testSideEffectObserver1.values).containsSequence(0..999)
+        testSideEffectObserver1.values.shouldContainExactly((0..999).toList())
     }
 
     @Test
@@ -64,9 +66,9 @@ internal class SideEffectTest {
         testSideEffectObserver2.awaitCount(3, timeout)
         testSideEffectObserver3.awaitCount(3, timeout)
 
-        assertThat(testSideEffectObserver1.values).doesNotContainSequence(action, action2, action3)
-        assertThat(testSideEffectObserver2.values).doesNotContainSequence(action, action2, action3)
-        assertThat(testSideEffectObserver3.values).doesNotContainSequence(action, action2, action3)
+        testSideEffectObserver1.values.shouldNotContainExactly(action, action2, action3)
+        testSideEffectObserver2.values.shouldNotContainExactly(action, action2, action3)
+        testSideEffectObserver3.values.shouldNotContainExactly(action, action2, action3)
     }
 
     @Test
@@ -84,7 +86,7 @@ internal class SideEffectTest {
 
         testSideEffectObserver1.awaitCount(3)
 
-        assertThat(testSideEffectObserver1.values).containsExactly(action, action2, action3)
+        testSideEffectObserver1.values.shouldContainExactly(action, action2, action3)
     }
 
     @Test
@@ -105,7 +107,7 @@ internal class SideEffectTest {
 
         testSideEffectObserver1.awaitCount(3, 10L)
 
-        assertThat(testSideEffectObserver2.values).isEmpty()
+        testSideEffectObserver2.values.shouldBeEmpty()
     }
 
     @Test
@@ -129,8 +131,8 @@ internal class SideEffectTest {
         val testSideEffectObserver2 = container.sideEffectFlow.test()
         testSideEffectObserver2.awaitCount(1000)
 
-        assertThat(testSideEffectObserver1.values).containsExactly(action)
-        assertThat(testSideEffectObserver2.values).containsExactlyElementsOf((0..999).toList())
+        testSideEffectObserver1.values.shouldContainExactly(action)
+        testSideEffectObserver2.values.shouldContainExactly((0..999).toList())
     }
 
     private fun Container<Unit, Int>.someFlow(action: Int) = orbit {

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/internal/StateTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/internal/StateTest.kt
@@ -21,9 +21,10 @@ import com.babylon.orbit2.container
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.test
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -37,7 +38,7 @@ internal class StateTest {
 
         testStateObserver.awaitCount(1)
 
-        assertThat(testStateObserver.values).containsExactly(initialState)
+        testStateObserver.values.shouldContainExactly(initialState)
     }
 
     @Test
@@ -52,11 +53,11 @@ internal class StateTest {
         val testStateObserver2 = middleware.container.stateFlow.test()
         testStateObserver2.awaitCount(1)
 
-        assertThat(testStateObserver.values).containsExactly(
+        testStateObserver.values.shouldContainExactly(
             initialState,
             TestState(action)
         )
-        assertThat(testStateObserver2.values).containsExactly(
+        testStateObserver2.values.shouldContainExactly(
             TestState(
                 action
             )
@@ -68,7 +69,7 @@ internal class StateTest {
         val initialState = TestState()
         val middleware = Middleware(initialState)
 
-        assertThat(middleware.container.currentState).isEqualTo(initialState)
+        middleware.container.currentState.shouldBe(initialState)
     }
 
     @Test
@@ -82,7 +83,7 @@ internal class StateTest {
 
         testStateObserver.awaitCount(2)
 
-        assertThat(middleware.container.currentState).isEqualTo(testStateObserver.values.last())
+        middleware.container.currentState.shouldBe(testStateObserver.values.last())
     }
 
     private data class TestState(val id: Int = Random.nextInt())

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/simple/SimpleDslThreadingTest.kt
@@ -20,10 +20,10 @@ import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import kotlin.random.Random
@@ -44,7 +44,7 @@ internal class SimpleDslThreadingTest {
         middleware.reducer(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(ORBIT_THREAD_PREFIX)
     }
 
     @Test
@@ -56,7 +56,7 @@ internal class SimpleDslThreadingTest {
         middleware.transformer(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(ORBIT_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginThreadingTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/BaseDslPluginThreadingTest.kt
@@ -20,10 +20,10 @@ import com.babylon.orbit2.Container
 import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import kotlin.random.Random
@@ -44,7 +44,7 @@ internal class BaseDslPluginThreadingTest {
         middleware.reducer(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(ORBIT_THREAD_PREFIX)
     }
 
     @Test
@@ -56,7 +56,7 @@ internal class BaseDslPluginThreadingTest {
         middleware.transformer(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -68,7 +68,7 @@ internal class BaseDslPluginThreadingTest {
         middleware.postingSideEffect(action)
 
         testFlowObserver.awaitCount(1)
-        assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(ORBIT_THREAD_PREFIX)
     }
 
     @Test
@@ -80,7 +80,7 @@ internal class BaseDslPluginThreadingTest {
 
         middleware.latch.await()
 
-        assertThat(middleware.threadName).startsWith(ORBIT_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(ORBIT_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/OrbitDslPluginsTest.kt
+++ b/orbit-2-core/src/test/java/com/babylon/orbit2/syntax/strict/OrbitDslPluginsTest.kt
@@ -17,8 +17,8 @@
 package com.babylon.orbit2.syntax.strict
 
 import com.babylon.orbit2.syntax.Operator
+import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.flow.Flow
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -31,7 +31,7 @@ internal class OrbitDslPluginsTest {
 
     @Test
     fun `base plugin is present by default`() {
-        assertThat(OrbitDslPlugins.plugins).containsExactly(BaseDslPlugin)
+        OrbitDslPlugins.plugins.shouldContainExactly(BaseDslPlugin)
     }
 
     @Test
@@ -39,7 +39,7 @@ internal class OrbitDslPluginsTest {
 
         OrbitDslPlugins.register(TestPlugin)
 
-        assertThat(OrbitDslPlugins.plugins).containsExactly(BaseDslPlugin, TestPlugin)
+        OrbitDslPlugins.plugins.shouldContainExactly(BaseDslPlugin, TestPlugin)
     }
 
     private object TestPlugin : OrbitDslPlugin {

--- a/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
+++ b/orbit-2-coroutines/src/test/java/com/babylon/orbit2/coroutines/CoroutineDslPluginThreadingTest.kt
@@ -22,13 +22,13 @@ import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.newSingleThreadContext
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -48,7 +48,7 @@ internal class CoroutineDslPluginThreadingTest {
         middleware.suspend(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -61,7 +61,7 @@ internal class CoroutineDslPluginThreadingTest {
         middleware.flow(action)
 
         testFlowObserver.awaitCount(5)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/DelegatingLiveDataTest.kt
@@ -17,6 +17,10 @@
 package com.babylon.orbit2.livedata
 
 import androidx.lifecycle.Lifecycle
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,11 +31,9 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -95,9 +97,9 @@ internal class DelegatingLiveDataTest {
 
         if (testCase.expectedSubscription) {
             observer.awaitCount(1)
-            assertThat(observer.values).containsExactly(action)
+            observer.values.shouldContainExactly(action)
         } else {
-            assertThat(observer.values).isEmpty()
+            observer.values.shouldBeEmpty()
         }
     }
 
@@ -118,11 +120,11 @@ internal class DelegatingLiveDataTest {
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_PAUSE)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
 
-        assertThrows<CancellationException> {
+        shouldThrow<CancellationException> {
             channel.sendBlocking(action2)
         }
 
-        assertThat(observer.values).containsExactly(action)
+        observer.values.shouldContainExactly(action)
     }
 
     @Test
@@ -136,7 +138,7 @@ internal class DelegatingLiveDataTest {
 
         channel.sendBlocking(action)
 
-        assertThat(observer.values).containsExactly(action)
-        assertThat(liveData.value).isNull()
+        observer.values.shouldContainExactly(action)
+        liveData.value.shouldBeNull()
     }
 }

--- a/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
+++ b/orbit-2-livedata/src/test/java/com/babylon/orbit2/livedata/LiveDataDslPluginDslThreadingTest.kt
@@ -23,13 +23,13 @@ import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.sideEffect
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -76,7 +76,8 @@ internal class LiveDataDslPluginDslThreadingTest {
         }
 
         sideEffects.awaitCount(1)
-        assertThat(threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+
+        threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava1/src/test/java/com/babylon/orbit2/rxjava1/RxJava1DslPluginDslThreadingTest.kt
@@ -22,10 +22,10 @@ import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import rx.Completable
 import rx.Observable
@@ -48,7 +48,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         middleware.single(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -61,7 +61,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         middleware.completable(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -74,7 +74,7 @@ internal class RxJava1DslPluginDslThreadingTest {
         middleware.observable(action)
 
         testFlowObserver.awaitCount(5)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
+++ b/orbit-2-rxjava3/src/test/java/com/babylon/orbit2/rxjava3/RxJava3DslPluginDslThreadingTest.kt
@@ -22,6 +22,7 @@ import com.babylon.orbit2.internal.RealContainer
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.test
+import io.kotest.matchers.string.shouldStartWith
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Observable
@@ -29,7 +30,6 @@ import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.newSingleThreadContext
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import kotlin.random.Random
@@ -50,7 +50,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         middleware.single(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -63,7 +63,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         middleware.maybe(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -75,7 +75,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         middleware.maybeNot(action)
 
         middleware.latch.await()
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -88,7 +88,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         middleware.completable(action)
 
         testFlowObserver.awaitCount(2)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     @Test
@@ -101,7 +101,7 @@ internal class RxJava3DslPluginDslThreadingTest {
         middleware.observable(action)
 
         testFlowObserver.awaitCount(5)
-        assertThat(middleware.threadName).startsWith(BACKGROUND_THREAD_PREFIX)
+        middleware.threadName.shouldStartWith(BACKGROUND_THREAD_PREFIX)
     }
 
     private data class TestState(val id: Int)

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitAssertionsTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitAssertionsTest.kt
@@ -16,9 +16,9 @@
 
 package com.babylon.orbit2
 
-import org.assertj.core.api.Assertions.assertThat
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class OrbitAssertionsTest {
     @Test
@@ -33,20 +33,19 @@ class OrbitAssertionsTest {
         )
 
         // When I assert the state list
-        val throwable = assertThrows<AssertionError> {
+        val throwable = shouldThrow<AssertionError> {
             assertStatesInOrder(stateList, assertions, TestState())
         }
 
         // Then The failure message points us to the failed assertion
-        assertThat(throwable)
-            .hasMessage(
-                "Failed assertions at indices 0..2, expected states but never received:\n" +
-                        "[" +
-                        "TestState(label=foobar, index=1), " +
-                        "TestState(label=foobarbaz, index=1), " +
-                        "TestState(label=foobarbaz, index=2)" +
-                        "]"
-            )
+        throwable.shouldHaveMessage(
+            "Failed assertions at indices 0..2, expected states but never received:\n" +
+                    "[" +
+                    "TestState(label=foobar, index=1), " +
+                    "TestState(label=foobarbaz, index=1), " +
+                    "TestState(label=foobarbaz, index=2)" +
+                    "]"
+        )
     }
 
     @Test
@@ -140,16 +139,15 @@ class OrbitAssertionsTest {
         )
 
         // When I assert the state list
-        val throwable = assertThrows<AssertionError> {
+        val throwable = shouldThrow<AssertionError> {
             assertStatesInOrder(stateList, assertions, TestState())
         }
 
         // Then The failure message points us to the failed assertion
-        assertThat(throwable)
-            .hasMessage(
-                "Expected 3 states but more were emitted:\n" +
-                        "[TestState(label=foobarbaz, index=4), TestState(label=foobarbaz, index=6)]"
-            )
+        throwable.shouldHaveMessage(
+            "Expected 3 states but more were emitted:\n" +
+                    "[TestState(label=foobarbaz, index=4), TestState(label=foobarbaz, index=6)]"
+        )
     }
 
     @Test
@@ -168,16 +166,15 @@ class OrbitAssertionsTest {
         )
 
         // When I assert the state list
-        val throwable = assertThrows<AssertionError> {
+        val throwable = shouldThrow<AssertionError> {
             assertStatesInOrder(stateList, assertions, TestState())
         }
 
         // Then The failure message points us to the failed assertion
-        assertThat(throwable)
-            .hasMessage(
-                "Failed assertion at index 0. Expected <TestState(label=foobaz, index=1)>, " +
-                        "actual <TestState(label=foobar, index=1)>."
-            )
+        throwable.shouldHaveMessage(
+            "Failed assertion at index 0. Expected <TestState(label=foobaz, index=1)>, " +
+                    "actual <TestState(label=foobar, index=1)>."
+        )
     }
 
     @Test
@@ -201,7 +198,7 @@ class OrbitAssertionsTest {
                 )
 
                 // Then The assertion fails
-                assertThrows<AssertionError> {
+                shouldThrow<AssertionError> {
                     assertStatesInOrder(stateList, assertions, TestState())
                 }
             }
@@ -229,7 +226,7 @@ class OrbitAssertionsTest {
                 val assertions: List<TestState.() -> TestState> = it
 
                 // Then The assertion fails
-                assertThrows<AssertionError> {
+                shouldThrow<AssertionError> {
                     assertStatesInOrder(stateList, assertions, TestState())
                 }
             }

--- a/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
+++ b/orbit-2-test/src/test/java/com/babylon/orbit2/OrbitTestingTest.kt
@@ -20,16 +20,16 @@ import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.syntax.strict.sideEffect
 import com.babylon.orbit2.syntax.strict.transform
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import kotlin.random.Random
-import kotlin.test.assertEquals
 
 class OrbitTestingTest {
     companion object {
@@ -75,11 +75,11 @@ class OrbitTestingTest {
             val testStateObserver = testSubject.container.stateFlow.test()
             testStateObserver.awaitCount(1)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(someRandomState)
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Expected <$someRandomState>, actual <$initialState>."
             )
         }
@@ -126,7 +126,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     states(
                         { copy(count = action) }
@@ -134,7 +134,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Expected 1 states but more were emitted:\n" +
                         "[State(count=$action2)]"
             )
@@ -158,7 +158,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = 1000L) {
                     states(
                         { copy(count = action) },
@@ -168,7 +168,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Failed assertions at indices 2..2, expected states but never received:\n" +
                         "[State(count=$action3)]"
             )
@@ -193,7 +193,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = 1000L) {
                     states(
                         { copy(count = action) },
@@ -204,7 +204,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Failed assertions at indices 2..3, expected states but never received:\n" +
                         "[State(count=$action3), State(count=$action4)]"
             )
@@ -228,7 +228,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     states(
                         { copy(count = action2) },
@@ -237,7 +237,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Failed assertion at index 0. " +
                         "Expected <State(count=$action2)>, actual <State(count=$action)>."
             )
@@ -261,7 +261,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     states(
                         { copy(count = action2) },
@@ -270,7 +270,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Failed assertion at index 0. " +
                         "Expected <State(count=$action2)>, actual <State(count=$action)>."
             )
@@ -293,7 +293,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     states(
                         { copy(count = action2) },
@@ -302,7 +302,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Failed assertion at index 0. " +
                         "Expected <State(count=$action2)>, actual <State(count=$action)>."
             )
@@ -355,7 +355,7 @@ class OrbitTestingTest {
             testSubject.something(action2)
             testStateObserver.awaitCount(3)
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     states(
                         { initialState },
@@ -364,7 +364,7 @@ class OrbitTestingTest {
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Expected 2 states but more were emitted:\n" +
                         "[State(count=$action2)]\n\n" +
                         "Caution: 1 assertions were dropped as they encountered a current state " +
@@ -420,13 +420,13 @@ class OrbitTestingTest {
 
             sideEffects.forEach { testSubject.something(it) }
 
-            val throwable = assertThrows<AssertionError> {
+            val throwable = shouldThrow<AssertionError> {
                 testSubject.assert(initialState, timeoutMillis = TIMEOUT) {
                     postedSideEffects(sideEffects2)
                 }
             }
 
-            assertThat(throwable.message).contains(
+            throwable.message.shouldContain(
                 "Expected <$sideEffects2>, actual <$sideEffects>."
             )
         }
@@ -461,10 +461,7 @@ class OrbitTestingTest {
 
             testSubject.test(initialState)
 
-            assertEquals(
-                0,
-                mockDependency.createCallCount
-            )
+            mockDependency.createCallCount.shouldBe(0)
         }
 
         @Test
@@ -475,10 +472,7 @@ class OrbitTestingTest {
 
             testSubject.test(initialState = initialState, runOnCreate = true)
 
-            assertEquals(
-                1,
-                mockDependency.createCallCount
-            )
+            mockDependency.createCallCount.shouldBe(1)
         }
 
         @Test
@@ -491,14 +485,8 @@ class OrbitTestingTest {
 
             spy.something()
 
-            assertEquals(
-                1,
-                mockDependency.something1CallCount
-            )
-            assertEquals(
-                0,
-                mockDependency.something2CallCount
-            )
+            mockDependency.something1CallCount.shouldBe(1)
+            mockDependency.something2CallCount.shouldBe(0)
         }
 
         private inner class GeneralTestMiddleware(private val dependency: BogusDependency) :

--- a/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-2-viewmodel/src/test/java/com/babylon/orbit2/viewmodel/ViewModelExtensionsKtTest.kt
@@ -23,8 +23,8 @@ import com.babylon.orbit2.ContainerHost
 import com.babylon.orbit2.syntax.strict.orbit
 import com.babylon.orbit2.syntax.strict.reduce
 import com.babylon.orbit2.test
+import io.kotest.matchers.shouldBe
 import kotlinx.android.parcel.Parcelize
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -37,7 +37,7 @@ class ViewModelExtensionsKtTest {
 
         val middleware = Middleware(savedStateHandle, initialState)
 
-        assertThat(middleware.container.currentState).isEqualTo(savedState)
+        middleware.container.currentState.shouldBe(savedState)
     }
 
     @Test
@@ -47,7 +47,7 @@ class ViewModelExtensionsKtTest {
 
         val middleware = Middleware(savedStateHandle, initialState)
 
-        assertThat(middleware.container.currentState).isEqualTo(initialState)
+        middleware.container.currentState.shouldBe(initialState)
     }
 
     @Test
@@ -62,9 +62,7 @@ class ViewModelExtensionsKtTest {
 
         testStateObserver.awaitCount(2)
 
-        assertThat(savedStateHandle.get<TestState?>(SAVED_STATE_KEY)).isEqualTo(
-            TestState(something)
-        )
+        savedStateHandle.get<TestState?>(SAVED_STATE_KEY).shouldBe(TestState(something))
     }
 
     @Test
@@ -81,7 +79,7 @@ class ViewModelExtensionsKtTest {
         // Used to trigger execution of onCreate
         middleware.container.stateFlow.test().awaitCount(1)
 
-        assertThat(onCreateState).isEqualTo(savedState)
+        onCreateState.shouldBe(savedState)
     }
 
     @Test
@@ -97,7 +95,7 @@ class ViewModelExtensionsKtTest {
         // Used to trigger execution of onCreate
         middleware.container.stateFlow.test().awaitCount(1)
 
-        assertThat(onCreateState).isEqualTo(initialState)
+        onCreateState.shouldBe(initialState)
     }
 
     private class Middleware(


### PR DESCRIPTION
AssertJ is JVM based, replacing with Kotlin multiplatform assertions from Kotest